### PR TITLE
Obsolete old inferences

### DIFF
--- a/src/ontology/components/lost-inferred-subsumptions-pre-odk.owl
+++ b/src/ontology/components/lost-inferred-subsumptions-pre-odk.owl
@@ -302,10 +302,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001025>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001026>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001028>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001046>))
-Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001047>))
-Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001049>))
-Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001050>))
-Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001051>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001052>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001053>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001054>))
@@ -1502,7 +1498,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006671>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006672>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006681>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006682>))
-Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006690>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006693>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006694>))
 Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006705>))
@@ -2357,36 +2352,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001018> ObjectSomeValuesFrom(<h
 # Class: <http://purl.obolibrary.org/obo/FYPO_0001025> (<http://purl.obolibrary.org/obo/FYPO_0001025>)
 
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001025> <http://purl.obolibrary.org/obo/FYPO_0006915>)
-
-# Class: <http://purl.obolibrary.org/obo/FYPO_0001047> (<http://purl.obolibrary.org/obo/FYPO_0001047>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001047> <http://purl.obolibrary.org/obo/FYPO_0000002>)
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000337>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
-
-# Class: <http://purl.obolibrary.org/obo/FYPO_0001049> (<http://purl.obolibrary.org/obo/FYPO_0001049>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> <http://purl.obolibrary.org/obo/FYPO_0002273>)
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000951>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
-
-# Class: <http://purl.obolibrary.org/obo/FYPO_0001050> (<http://purl.obolibrary.org/obo/FYPO_0001050>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> <http://purl.obolibrary.org/obo/FYPO_0002199>)
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
-
-# Class: <http://purl.obolibrary.org/obo/FYPO_0001051> (<http://purl.obolibrary.org/obo/FYPO_0001051>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> <http://purl.obolibrary.org/obo/FYPO_0002273>)
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001490>))
 
 # Class: <http://purl.obolibrary.org/obo/FYPO_0001052> (<http://purl.obolibrary.org/obo/FYPO_0001052>)
 
@@ -3902,8 +3867,9 @@ SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003159> <http://purl.obolibrary
 
 # Class: <http://purl.obolibrary.org/obo/FYPO_0003165> (<http://purl.obolibrary.org/obo/FYPO_0003165>)
 
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> <http://purl.obolibrary.org/obo/FYPO_0001047>)
+SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
+SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000337>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 
@@ -6425,12 +6391,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006681> <http://purl.obolibrary
 # Class: <http://purl.obolibrary.org/obo/FYPO_0006682> (<http://purl.obolibrary.org/obo/FYPO_0006682>)
 
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006682> <http://purl.obolibrary.org/obo/FYPO_0003011>)
-
-# Class: <http://purl.obolibrary.org/obo/FYPO_0006690> (<http://purl.obolibrary.org/obo/FYPO_0006690>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006690> <http://purl.obolibrary.org/obo/FYPO_0000002>)
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
-SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 
 # Class: <http://purl.obolibrary.org/obo/FYPO_0006693> (<http://purl.obolibrary.org/obo/FYPO_0006693>)
 

--- a/src/ontology/components/lost-inferred-subsumptions-pre-odk.owl
+++ b/src/ontology/components/lost-inferred-subsumptions-pre-odk.owl
@@ -7,405 +7,2833 @@ Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 Prefix(dcterms:=<http://purl.org/dc/terms/>)
 
+
 Ontology(<http://purl.obolibrary.org/obo/fypo/components/lost-inferred-subsumptions-pre-odk.owl>
 Annotation(dce:description "Lost subclass and other relation axioms due to the migration to ODK in May 2020.")
+
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000001>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000002>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000008>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000012>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000014>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000015>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000016>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000017>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000020>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000021>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000023>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000024>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000025>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000026>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000030>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000031>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000032>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000033>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000045>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000049>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000050>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000051>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000052>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000054>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000055>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000060>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000061>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000062>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000063>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000085>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000087>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000088>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000089>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000097>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000102>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000117>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000118>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000121>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000123>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000124>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000126>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000127>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000128>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000129>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000131>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000133>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000134>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000138>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000140>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000141>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000142>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000145>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000151>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000154>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000155>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000158>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000164>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000165>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000172>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000174>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000175>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000177>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000178>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000184>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000186>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000190>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000191>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000196>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000197>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000200>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000202>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000204>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000209>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000223>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000224>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000229>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000231>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000233>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000253>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000255>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000257>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000260>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000263>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000266>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000272>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000273>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000274>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000276>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000281>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000283>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000284>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000290>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000294>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000295>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000305>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000307>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000309>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000315>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000320>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000324>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000325>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000335>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000336>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000337>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000338>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000339>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000344>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000346>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000347>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000348>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000349>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000350>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000352>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000353>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000354>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000356>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000357>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000359>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000360>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000361>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000362>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000364>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000368>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000370>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000389>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000398>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000407>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000409>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000417>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000420>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000421>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000422>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000426>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000443>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000444>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000449>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000450>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000451>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000464>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000468>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000470>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000502>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000506>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000517>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000532>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000533>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000544>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000545>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000547>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000548>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000560>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000563>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000568>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000569>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000573>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000574>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000577>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000580>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000602>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000607>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000608>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000610>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000620>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000622>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000627>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000628>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000636>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000641>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000645>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000646>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000647>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000648>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000670>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000673>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000679>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000682>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000683>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000689>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000701>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000704>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000705>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000711>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000712>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000717>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000732>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000733>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000734>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000737>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000769>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000771>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000779>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000780>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000781>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000782>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000783>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000784>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000790>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000791>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000801>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000802>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000804>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000805>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000806>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000807>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000808>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000809>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000810>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000811>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000812>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000813>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000814>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000815>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000824>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000825>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000826>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000827>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000828>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000832>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000833>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000834>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000835>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000836>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000837>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000839>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000846>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000847>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000848>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000859>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000860>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000864>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000865>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000867>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000869>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000871>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000872>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000874>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000876>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000880>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000881>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000882>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000884>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000885>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000889>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000890>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000892>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000893>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000895>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000899>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000900>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000909>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000911>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000926>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000930>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000931>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000932>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000934>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000935>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000938>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000940>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000941>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000942>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000943>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000944>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000945>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000946>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000947>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000948>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000949>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000950>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000951>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000952>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000966>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000967>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000968>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0000998>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001001>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001008>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001009>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001010>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001018>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001025>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001026>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001028>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001047>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001049>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001050>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001051>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001052>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001053>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001054>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001059>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001063>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001071>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001078>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001079>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001092>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001102>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001112>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001117>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001118>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001120>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001121>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001122>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001123>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001124>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001126>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001127>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001129>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001130>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001151>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001152>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001165>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001170>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001194>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001196>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001197>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001198>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001199>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001204>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001208>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001209>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001211>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001215>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001219>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001222>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001223>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001225>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001226>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001228>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001248>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001252>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001253>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001269>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001270>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001283>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001289>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001313>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001315>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001317>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001319>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001320>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001321>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001322>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001324>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001325>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001326>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001327>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001329>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001330>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001332>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001333>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001334>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001336>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001337>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001338>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001339>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001341>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001345>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001346>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001347>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001350>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001351>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001352>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001353>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001354>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001356>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001362>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001363>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001369>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001370>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001375>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001385>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001389>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001390>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001391>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001392>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001399>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001406>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001412>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001417>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001418>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001424>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001425>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001426>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001427>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001429>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001430>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001441>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001447>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001458>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001474>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001489>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001490>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001491>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001492>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001493>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001494>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001495>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001496>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001497>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001505>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001507>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001509>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001510>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001511>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001512>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001514>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001515>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001532>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001534>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001552>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001553>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001562>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001563>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001564>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001565>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001567>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001568>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001571>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001574>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001581>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001585>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001586>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001587>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001607>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001608>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001609>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001610>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001611>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001612>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001613>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001619>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001621>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001623>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001625>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001626>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001627>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001628>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001629>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001631>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001632>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001633>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001634>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001635>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001636>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001637>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001638>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001639>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001640>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001641>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001642>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001643>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001645>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001646>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001648>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001677>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001683>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001703>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001704>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001705>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001712>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001726>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001727>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001728>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001729>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001731>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001732>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001733>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001778>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001782>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001783>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001791>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001796>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001797>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001798>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001837>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001852>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001855>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001861>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001862>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001877>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001878>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001879>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001890>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001910>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001914>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001916>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001917>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001919>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001924>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001928>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001930>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001946>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001949>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001953>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001955>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001967>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001974>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001978>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001985>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001992>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0001994>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002014>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002017>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002018>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002020>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002023>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002024>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002025>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002026>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002029>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002030>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002031>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002038>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002042>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002049>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002050>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002051>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002066>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002069>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002070>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002071>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002072>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002076>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002083>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002084>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002086>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002089>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002092>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002099>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002103>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002105>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002106>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002107>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002108>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002109>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002110>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002111>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002112>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002113>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002128>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002136>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002137>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002138>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002142>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002151>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002159>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002167>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002176>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002187>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002189>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002190>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002191>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002193>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002196>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002197>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002199>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002200>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002207>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002208>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002215>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002230>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002240>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002241>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002242>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002250>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002251>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002252>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002253>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002257>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002258>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002265>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002266>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002273>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002276>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002277>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002279>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002282>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002286>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002303>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002313>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002318>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002319>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002321>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002323>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002324>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002326>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002327>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002331>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002333>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002337>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002339>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002341>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002342>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002344>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002345>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002355>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002362>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002363>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002365>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002367>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002374>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002377>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002380>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002381>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002382>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002386>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002395>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002397>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002398>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002399>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002401>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002402>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002403>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002405>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002406>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002410>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002411>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002414>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002415>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002421>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002423>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002427>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002429>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002434>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002436>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002437>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002438>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002439>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002442>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002451>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002452>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002455>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002456>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002457>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002459>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002460>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002462>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002463>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002467>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002476>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002478>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002479>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002482>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002483>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002488>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002516>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002517>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002518>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002519>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002522>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002525>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002529>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002540>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002552>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002560>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002564>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002579>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002584>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002585>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002596>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002597>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002598>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002602>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002603>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002605>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002606>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002608>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002609>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002627>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002629>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002635>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002639>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002654>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002655>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002656>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002660>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002699>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002704>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002715>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002722>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002730>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002731>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002732>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002734>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002737>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002739>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002746>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002760>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002762>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002768>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002772>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002779>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002780>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002787>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002788>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002790>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002791>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002792>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002793>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002795>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002796>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002797>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002798>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002800>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002816>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002818>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002820>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002821>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002822>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002829>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002835>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002839>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002840>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002842>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002843>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002845>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002847>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002852>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002858>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002873>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002875>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002876>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002879>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002888>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002889>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002900>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002901>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002902>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002903>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002904>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002909>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002911>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002912>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002913>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002941>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002943>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002945>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002946>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002957>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002967>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002969>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002970>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002978>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002987>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002991>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002992>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002994>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0002999>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003002>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003004>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003005>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003009>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003010>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003024>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003037>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003048>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003052>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003053>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003054>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003055>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003056>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003061>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003064>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003068>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003079>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003088>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003096>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003101>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003102>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003114>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003117>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003119>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003120>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003122>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003124>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003125>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003127>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003128>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003130>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003133>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003138>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003143>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003150>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003159>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003161>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003165>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003171>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003184>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003185>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003186>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003192>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003193>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003195>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003196>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003197>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003198>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003204>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003205>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003210>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003211>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003213>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003225>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003230>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003231>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003232>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003233>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003234>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003241>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003245>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003246>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003250>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003263>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003268>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003269>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003277>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003278>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003280>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003286>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003290>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003291>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003298>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003305>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003313>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003327>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003328>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003329>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003333>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003341>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003342>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003346>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003352>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003363>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003369>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003378>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003389>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003402>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003413>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003415>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003423>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003424>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003429>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003430>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003440>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003445>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003448>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003449>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003452>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003468>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003479>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003481>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003489>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003498>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003500>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003501>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003503>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003504>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003532>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003549>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003552>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003553>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003556>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003557>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003560>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003561>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003565>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003570>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003571>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003572>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003585>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003586>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003591>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003592>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003593>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003595>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003607>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003610>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003625>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003633>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003634>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003635>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003636>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003647>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003653>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003657>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003677>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003682>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003684>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003685>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003689>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003693>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003695>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003696>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003700>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003710>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003711>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003714>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003716>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003728>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003740>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003744>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003745>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003746>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003751>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003754>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003755>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003756>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003758>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003759>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003760>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003763>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003779>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003780>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003781>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003782>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003783>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003785>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003787>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003788>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003791>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003792>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003795>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003796>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003802>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003810>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003814>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003825>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003826>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003829>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003835>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003841>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003844>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003871>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003873>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003875>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003876>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003887>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003890>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003904>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003905>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003915>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003916>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003923>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003931>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003934>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003935>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003947>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003950>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003972>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003974>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003975>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003976>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003977>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003978>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003979>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003984>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003985>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003986>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003987>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003988>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0003989>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004002>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004015>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004021>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004022>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004031>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004042>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004045>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004047>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004056>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004061>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004064>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004066>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004074>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004076>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004077>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004086>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004088>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004094>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004103>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004104>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004105>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004106>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004107>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004112>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004113>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004127>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004137>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004139>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004140>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004141>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004159>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004170>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004197>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004198>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004205>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004213>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004226>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004227>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004236>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004241>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004254>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004255>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004256>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004257>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004261>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004272>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004295>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004301>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004312>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004313>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004315>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004321>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004326>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004334>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004339>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004345>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004346>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004351>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004352>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004353>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004367>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004369>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004382>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004396>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004416>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004418>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004429>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004440>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004441>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004446>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004448>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004453>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004468>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004473>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004483>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004493>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004494>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004495>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004496>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004498>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004502>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004510>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004511>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004521>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004523>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004526>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004527>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004531>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004532>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004533>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004535>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004537>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004538>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004539>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004554>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004559>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004562>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004567>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004568>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004572>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004577>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004582>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004592>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004594>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004598>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004603>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004608>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004609>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004611>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004612>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004619>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004624>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004626>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004638>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004639>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004651>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004656>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004657>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004658>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004672>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004673>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004684>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004688>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004691>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004703>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004715>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004716>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004731>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004735>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004736>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004738>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004748>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004750>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004753>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004754>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004755>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004756>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004761>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004762>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004767>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004768>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004769>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004770>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004771>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004772>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004773>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004774>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004775>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004776>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004780>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004787>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004790>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004802>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004803>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004811>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004816>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004830>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004831>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004839>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004842>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004851>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004852>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004859>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004860>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004861>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004862>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004863>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004864>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004865>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004867>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004874>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004891>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004902>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004904>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004912>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004916>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004920>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004922>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004928>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004930>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004947>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004953>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004957>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004958>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004960>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004961>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004965>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004970>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004979>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004988>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0004990>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005004>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005019>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005023>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005024>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005027>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005028>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005045>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005062>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005063>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005064>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005065>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005066>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005077>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005096>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005097>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005103>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005118>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005142>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005143>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005144>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005145>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005149>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005155>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005158>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005162>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005167>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005169>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005182>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005188>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005194>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005196>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005201>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005202>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005208>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005210>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005215>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005225>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005229>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005234>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005237>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005263>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005268>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005271>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005277>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005289>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005290>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005295>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005306>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005308>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005309>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005310>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005314>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005316>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005321>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005333>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005338>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005339>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005343>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005344>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005355>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005359>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005362>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005367>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005377>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005378>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005379>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005382>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005385>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005394>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005419>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005422>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005424>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005425>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005426>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005427>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005429>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005438>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005440>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005441>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005443>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005444>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005447>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005449>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005462>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005463>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005467>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005468>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005475>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005493>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005494>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005496>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005497>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005501>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005502>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005507>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005509>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005513>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005514>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005515>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005518>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005534>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005535>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005536>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005544>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005555>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005556>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005558>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005559>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005560>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005561>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005562>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005563>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005564>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005566>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005568>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005576>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005585>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005590>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005594>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005598>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005601>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005603>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005608>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005611>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005662>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005664>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005665>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005667>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005672>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005673>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005674>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005676>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005679>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005683>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005684>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005687>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005689>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005691>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005692>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005698>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005709>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005711>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005720>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005721>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005735>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005755>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005758>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005773>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005775>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005778>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005779>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005782>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005784>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005785>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005789>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005790>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005791>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005795>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005796>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005797>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005811>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005814>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005817>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005823>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005824>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005831>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005832>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005833>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005834>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005836>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005837>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005844>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005845>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005857>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005861>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005862>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005869>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005873>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005888>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005894>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005895>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005896>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005897>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005898>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005921>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005922>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005973>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005974>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005988>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0005994>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006003>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006012>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006022>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006023>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006028>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006031>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006032>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006034>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006047>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006050>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006051>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006053>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006054>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006059>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006076>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006077>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006082>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006101>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006103>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006112>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006117>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006134>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006142>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006148>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006165>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006166>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006167>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006188>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006191>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006192>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006193>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006196>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006197>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006198>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006199>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006201>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006208>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006209>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006221>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006222>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006223>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006229>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006230>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006231>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006240>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006250>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006262>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006270>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006272>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006274>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006279>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006290>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006292>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006294>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006300>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006313>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006328>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006329>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006339>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006351>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006356>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006359>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006360>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006364>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006370>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006379>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006386>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006387>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006393>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006397>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006426>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006427>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006428>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006430>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006460>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006461>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006462>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006465>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006467>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006468>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006470>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006474>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006476>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006479>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006480>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006481>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006486>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006488>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006490>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006502>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006519>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006521>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006529>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006532>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006550>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006551>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006557>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006558>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006583>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006588>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006589>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006590>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006599>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006600>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006612>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006613>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006614>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006615>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006616>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006617>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006623>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006624>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006626>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006627>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006628>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006629>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006630>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006633>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006634>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006635>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006656>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006669>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006671>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006672>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006681>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006682>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006690>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006693>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006694>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006705>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006712>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006718>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006740>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006743>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006751>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006752>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006753>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006759>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006764>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006775>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006782>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006784>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006794>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006795>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006796>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006799>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006801>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006808>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006812>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006814>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006815>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006818>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006819>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006821>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006822>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006823>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006825>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006827>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006828>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006837>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006839>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006843>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006853>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006861>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006862>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006866>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006872>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006883>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006884>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006885>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006886>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006895>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006896>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006915>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006917>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006936>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006945>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006946>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006953>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006955>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006974>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006978>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006987>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006997>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0006998>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007004>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007008>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007009>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007011>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007027>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007031>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007051>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007052>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007070>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007082>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007086>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007094>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007095>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007096>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007099>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007101>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007115>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007131>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007133>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007136>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007137>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007138>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007140>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007146>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007165>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007169>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007173>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007175>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007176>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007181>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007186>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007193>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007194>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007195>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007205>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007213>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007218>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007222>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007230>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007231>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007232>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007233>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007254>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007257>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007258>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007259>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007260>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007262>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007265>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007272>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007274>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007276>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007282>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007289>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007290>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007293>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007301>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007307>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007309>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007312>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007313>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007315>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007316>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007321>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007322>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007337>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007342>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007343>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007344>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007357>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007373>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007374>))
+Declaration(Class(<http://purl.obolibrary.org/obo/FYPO_0007375>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000050>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/BFO_0000051>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000052>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/fypo#has_output>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/fypo#output_of>))
+Declaration(AnnotationProperty(dce:description))
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000008> (<http://purl.obolibrary.org/obo/FYPO_0000008>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000008> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000013> (<http://purl.obolibrary.org/obo/FYPO_0000013>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000026>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000015> (<http://purl.obolibrary.org/obo/FYPO_0000015>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000015> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000017> (<http://purl.obolibrary.org/obo/FYPO_0000017>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000017> <http://purl.obolibrary.org/obo/FYPO_0001126>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000017> <http://purl.obolibrary.org/obo/FYPO_0001127>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000021> (<http://purl.obolibrary.org/obo/FYPO_0000021>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000021> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000024> (<http://purl.obolibrary.org/obo/FYPO_0000024>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000024> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000030> (<http://purl.obolibrary.org/obo/FYPO_0000030>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000030> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000045> (<http://purl.obolibrary.org/obo/FYPO_0000045>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000045> <http://purl.obolibrary.org/obo/FYPO_0005447>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000050> (<http://purl.obolibrary.org/obo/FYPO_0000050>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000807>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000062> (<http://purl.obolibrary.org/obo/FYPO_0000062>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000062> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000810>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000063> (<http://purl.obolibrary.org/obo/FYPO_0000063>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000063> <http://purl.obolibrary.org/obo/FYPO_0000860>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000085> (<http://purl.obolibrary.org/obo/FYPO_0000085>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000085> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000087> (<http://purl.obolibrary.org/obo/FYPO_0000087>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000087> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000088> (<http://purl.obolibrary.org/obo/FYPO_0000088>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000088> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000089> (<http://purl.obolibrary.org/obo/FYPO_0000089>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000089> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000097> (<http://purl.obolibrary.org/obo/FYPO_0000097>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000097> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000102> (<http://purl.obolibrary.org/obo/FYPO_0000102>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000102> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000118> (<http://purl.obolibrary.org/obo/FYPO_0000118>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000118> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000032>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000121> (<http://purl.obolibrary.org/obo/FYPO_0000121>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000121> <http://purl.obolibrary.org/obo/FYPO_0000679>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000123> (<http://purl.obolibrary.org/obo/FYPO_0000123>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000123> <http://purl.obolibrary.org/obo/FYPO_0000368>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000126> (<http://purl.obolibrary.org/obo/FYPO_0000126>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000126> <http://purl.obolibrary.org/obo/FYPO_0001356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000127> (<http://purl.obolibrary.org/obo/FYPO_0000127>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000127> <http://purl.obolibrary.org/obo/FYPO_0001356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000128> (<http://purl.obolibrary.org/obo/FYPO_0000128>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000128> <http://purl.obolibrary.org/obo/FYPO_0000001>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000131> (<http://purl.obolibrary.org/obo/FYPO_0000131>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000131> <http://purl.obolibrary.org/obo/FYPO_0001362>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000131> <http://purl.obolibrary.org/obo/FYPO_0002737>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000131> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/FYPO_0000337>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000131> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001574>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000133> (<http://purl.obolibrary.org/obo/FYPO_0000133>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000133> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000032>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000134> (<http://purl.obolibrary.org/obo/FYPO_0000134>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000134> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000141> (<http://purl.obolibrary.org/obo/FYPO_0000141>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000141> <http://purl.obolibrary.org/obo/FYPO_0001353>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000141> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000151> (<http://purl.obolibrary.org/obo/FYPO_0000151>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000151> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000154> (<http://purl.obolibrary.org/obo/FYPO_0000154>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000154> <http://purl.obolibrary.org/obo/FYPO_0000628>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000155> (<http://purl.obolibrary.org/obo/FYPO_0000155>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000155> <http://purl.obolibrary.org/obo/FYPO_0005447>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000164> (<http://purl.obolibrary.org/obo/FYPO_0000164>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000164> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000165> (<http://purl.obolibrary.org/obo/FYPO_0000165>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000165> <http://purl.obolibrary.org/obo/FYPO_0000628>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000172> (<http://purl.obolibrary.org/obo/FYPO_0000172>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000172> <http://purl.obolibrary.org/obo/FYPO_0000051>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000174> (<http://purl.obolibrary.org/obo/FYPO_0000174>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000174> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002946>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000175> (<http://purl.obolibrary.org/obo/FYPO_0000175>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000175> <http://purl.obolibrary.org/obo/FYPO_0000679>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000175> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000177> (<http://purl.obolibrary.org/obo/FYPO_0000177>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000177> <http://purl.obolibrary.org/obo/FYPO_0002737>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000177> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000338>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000178> (<http://purl.obolibrary.org/obo/FYPO_0000178>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000178> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000184> (<http://purl.obolibrary.org/obo/FYPO_0000184>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000184> <http://purl.obolibrary.org/obo/FYPO_0000628>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000191> (<http://purl.obolibrary.org/obo/FYPO_0000191>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000191> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000196> (<http://purl.obolibrary.org/obo/FYPO_0000196>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000196> <http://purl.obolibrary.org/obo/FYPO_0000679>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000196> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000197> (<http://purl.obolibrary.org/obo/FYPO_0000197>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000197> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000200> (<http://purl.obolibrary.org/obo/FYPO_0000200>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000200> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000202> (<http://purl.obolibrary.org/obo/FYPO_0000202>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000202> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000204> (<http://purl.obolibrary.org/obo/FYPO_0000204>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000204> <http://purl.obolibrary.org/obo/FYPO_0000360>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000204> <http://purl.obolibrary.org/obo/FYPO_0000506>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000204> <http://purl.obolibrary.org/obo/FYPO_0004852>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000209> (<http://purl.obolibrary.org/obo/FYPO_0000209>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000209> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000223> (<http://purl.obolibrary.org/obo/FYPO_0000223>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000224> (<http://purl.obolibrary.org/obo/FYPO_0000224>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000224> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000231> (<http://purl.obolibrary.org/obo/FYPO_0000231>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000231> <http://purl.obolibrary.org/obo/FYPO_0000801>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000233> (<http://purl.obolibrary.org/obo/FYPO_0000233>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000233> <http://purl.obolibrary.org/obo/FYPO_0004088>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000253> (<http://purl.obolibrary.org/obo/FYPO_0000253>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000253> <http://purl.obolibrary.org/obo/FYPO_0000689>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000255> (<http://purl.obolibrary.org/obo/FYPO_0000255>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000255> <http://purl.obolibrary.org/obo/FYPO_0001322>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000255> <http://purl.obolibrary.org/obo/FYPO_0002403>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000257> (<http://purl.obolibrary.org/obo/FYPO_0000257>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/FYPO_0000001>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000260> (<http://purl.obolibrary.org/obo/FYPO_0000260>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000260> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000263> (<http://purl.obolibrary.org/obo/FYPO_0000263>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000263> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000273> (<http://purl.obolibrary.org/obo/FYPO_0000273>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000273> <http://purl.obolibrary.org/obo/FYPO_0003161>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000274> (<http://purl.obolibrary.org/obo/FYPO_0000274>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000420>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000276> (<http://purl.obolibrary.org/obo/FYPO_0000276>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0005344>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000281> (<http://purl.obolibrary.org/obo/FYPO_0000281>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000281> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000281> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000952>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000281> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002787>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000283> (<http://purl.obolibrary.org/obo/FYPO_0000283>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000283> <http://purl.obolibrary.org/obo/FYPO_0000848>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000284> (<http://purl.obolibrary.org/obo/FYPO_0000284>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000284> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001270>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000305> (<http://purl.obolibrary.org/obo/FYPO_0000305>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000305> <http://purl.obolibrary.org/obo/FYPO_0000679>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000307> (<http://purl.obolibrary.org/obo/FYPO_0000307>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000307> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000346>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000307> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000309> (<http://purl.obolibrary.org/obo/FYPO_0000309>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000309> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000309> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000348>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000309> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000315> (<http://purl.obolibrary.org/obo/FYPO_0000315>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000315> <http://purl.obolibrary.org/obo/FYPO_0002452>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000315> <http://purl.obolibrary.org/obo/FYPO_0004750>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000320> (<http://purl.obolibrary.org/obo/FYPO_0000320>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000320> <http://purl.obolibrary.org/obo/FYPO_0002199>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000324> (<http://purl.obolibrary.org/obo/FYPO_0000324>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000324> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000274>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000339> (<http://purl.obolibrary.org/obo/FYPO_0000339>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000339> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000033>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000349> (<http://purl.obolibrary.org/obo/FYPO_0000349>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000349> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000806>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000350> (<http://purl.obolibrary.org/obo/FYPO_0000350>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000350> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000801>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000352> (<http://purl.obolibrary.org/obo/FYPO_0000352>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000352> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000353> (<http://purl.obolibrary.org/obo/FYPO_0000353>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000353> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000804>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000354> (<http://purl.obolibrary.org/obo/FYPO_0000354>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000354> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000805>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000356> (<http://purl.obolibrary.org/obo/FYPO_0000356>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000356> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000808>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000357> (<http://purl.obolibrary.org/obo/FYPO_0000357>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000357> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000568>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000359> (<http://purl.obolibrary.org/obo/FYPO_0000359>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000359> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000809>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000360> (<http://purl.obolibrary.org/obo/FYPO_0000360>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000360> <http://purl.obolibrary.org/obo/FYPO_0001337>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000361> (<http://purl.obolibrary.org/obo/FYPO_0000361>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000361> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000814>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000362> (<http://purl.obolibrary.org/obo/FYPO_0000362>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000811>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000368> (<http://purl.obolibrary.org/obo/FYPO_0000368>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000368> <http://purl.obolibrary.org/obo/FYPO_0004639>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000368> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000812>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000370> (<http://purl.obolibrary.org/obo/FYPO_0000370>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000370> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000389> (<http://purl.obolibrary.org/obo/FYPO_0000389>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000389> <http://purl.obolibrary.org/obo/FYPO_0001028>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000407> (<http://purl.obolibrary.org/obo/FYPO_0000407>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000407> <http://purl.obolibrary.org/obo/FYPO_0002734>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000409> (<http://purl.obolibrary.org/obo/FYPO_0000409>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000409> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000421> (<http://purl.obolibrary.org/obo/FYPO_0000421>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000421> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003504>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000422> (<http://purl.obolibrary.org/obo/FYPO_0000422>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003504>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000426> (<http://purl.obolibrary.org/obo/FYPO_0000426>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000426> <http://purl.obolibrary.org/obo/FYPO_0001071>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000464> (<http://purl.obolibrary.org/obo/FYPO_0000464>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000464> <http://purl.obolibrary.org/obo/FYPO_0005973>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000468> (<http://purl.obolibrary.org/obo/FYPO_0000468>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000468> <http://purl.obolibrary.org/obo/FYPO_0000679>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000468> <http://purl.obolibrary.org/obo/FYPO_0001363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000533> (<http://purl.obolibrary.org/obo/FYPO_0000533>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000533> <http://purl.obolibrary.org/obo/FYPO_0000502>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000533> <http://purl.obolibrary.org/obo/FYPO_0000532>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000560> (<http://purl.obolibrary.org/obo/FYPO_0000560>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000560> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000563> (<http://purl.obolibrary.org/obo/FYPO_0000563>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000563> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000568> (<http://purl.obolibrary.org/obo/FYPO_0000568>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000568> <http://purl.obolibrary.org/obo/FYPO_0000679>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000573> (<http://purl.obolibrary.org/obo/FYPO_0000573>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000573> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000574> (<http://purl.obolibrary.org/obo/FYPO_0000574>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000574> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000577> (<http://purl.obolibrary.org/obo/FYPO_0000577>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000577> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001117>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000580> (<http://purl.obolibrary.org/obo/FYPO_0000580>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000580> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000602> (<http://purl.obolibrary.org/obo/FYPO_0000602>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000602> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000607> (<http://purl.obolibrary.org/obo/FYPO_0000607>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000607> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000608> (<http://purl.obolibrary.org/obo/FYPO_0000608>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000608> <http://purl.obolibrary.org/obo/FYPO_0001334>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000337>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000610> (<http://purl.obolibrary.org/obo/FYPO_0000610>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000610> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000620> (<http://purl.obolibrary.org/obo/FYPO_0000620>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000620> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001946>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000636> (<http://purl.obolibrary.org/obo/FYPO_0000636>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000636> <http://purl.obolibrary.org/obo/FYPO_0001356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000645> (<http://purl.obolibrary.org/obo/FYPO_0000645>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000645> <http://purl.obolibrary.org/obo/FYPO_0001118>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000646> (<http://purl.obolibrary.org/obo/FYPO_0000646>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000646> <http://purl.obolibrary.org/obo/FYPO_0001118>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000647> (<http://purl.obolibrary.org/obo/FYPO_0000647>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000647> <http://purl.obolibrary.org/obo/FYPO_0001320>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000648> (<http://purl.obolibrary.org/obo/FYPO_0000648>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000648> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000648> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000670> (<http://purl.obolibrary.org/obo/FYPO_0000670>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000670> <http://purl.obolibrary.org/obo/FYPO_0001362>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000670> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000682> (<http://purl.obolibrary.org/obo/FYPO_0000682>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000682> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000683> (<http://purl.obolibrary.org/obo/FYPO_0000683>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000683> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0004916>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000701> (<http://purl.obolibrary.org/obo/FYPO_0000701>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000701> <http://purl.obolibrary.org/obo/FYPO_0001704>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000711> (<http://purl.obolibrary.org/obo/FYPO_0000711>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000711> <http://purl.obolibrary.org/obo/FYPO_0005097>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000712> (<http://purl.obolibrary.org/obo/FYPO_0000712>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000712> <http://purl.obolibrary.org/obo/FYPO_0000711>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000717> (<http://purl.obolibrary.org/obo/FYPO_0000717>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000717> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000737> (<http://purl.obolibrary.org/obo/FYPO_0000737>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000737> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000734>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000769> (<http://purl.obolibrary.org/obo/FYPO_0000769>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000769> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000815>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000780> (<http://purl.obolibrary.org/obo/FYPO_0000780>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000780> <http://purl.obolibrary.org/obo/FYPO_0004064>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000780> <http://purl.obolibrary.org/obo/FYPO_0004527>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000780> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000825>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000781> (<http://purl.obolibrary.org/obo/FYPO_0000781>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000781> <http://purl.obolibrary.org/obo/FYPO_0004064>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000781> <http://purl.obolibrary.org/obo/FYPO_0004527>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000781> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001117>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000782> (<http://purl.obolibrary.org/obo/FYPO_0000782>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000782> <http://purl.obolibrary.org/obo/FYPO_0004639>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000782> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000443>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000784> (<http://purl.obolibrary.org/obo/FYPO_0000784>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000784> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001129>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000791> (<http://purl.obolibrary.org/obo/FYPO_0000791>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000791> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000790>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000802> (<http://purl.obolibrary.org/obo/FYPO_0000802>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000802> <http://purl.obolibrary.org/obo/FYPO_0000295>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000805> (<http://purl.obolibrary.org/obo/FYPO_0000805>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000805> <http://purl.obolibrary.org/obo/FYPO_0001353>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000806> (<http://purl.obolibrary.org/obo/FYPO_0000806>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000806> <http://purl.obolibrary.org/obo/FYPO_0001353>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000824> (<http://purl.obolibrary.org/obo/FYPO_0000824>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000824> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000142>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000827> (<http://purl.obolibrary.org/obo/FYPO_0000827>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000827> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000834> (<http://purl.obolibrary.org/obo/FYPO_0000834>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000834> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000142>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000839> (<http://purl.obolibrary.org/obo/FYPO_0000839>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000502>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000846> (<http://purl.obolibrary.org/obo/FYPO_0000846>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000846> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001327>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000847> (<http://purl.obolibrary.org/obo/FYPO_0000847>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000847> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001324>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000848> (<http://purl.obolibrary.org/obo/FYPO_0000848>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000848> <http://purl.obolibrary.org/obo/FYPO_0001322>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000848> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000641>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000874> (<http://purl.obolibrary.org/obo/FYPO_0000874>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000874> <http://purl.obolibrary.org/obo/FYPO_0000867>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000880> (<http://purl.obolibrary.org/obo/FYPO_0000880>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000880> <http://purl.obolibrary.org/obo/FYPO_0000864>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000881> (<http://purl.obolibrary.org/obo/FYPO_0000881>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000881> <http://purl.obolibrary.org/obo/FYPO_0000865>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000884> (<http://purl.obolibrary.org/obo/FYPO_0000884>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000884> <http://purl.obolibrary.org/obo/FYPO_0000865>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000889> (<http://purl.obolibrary.org/obo/FYPO_0000889>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000889> <http://purl.obolibrary.org/obo/FYPO_0000885>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000890> (<http://purl.obolibrary.org/obo/FYPO_0000890>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000890> <http://purl.obolibrary.org/obo/FYPO_0000885>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000895> (<http://purl.obolibrary.org/obo/FYPO_0000895>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000895> <http://purl.obolibrary.org/obo/FYPO_0000359>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000900> (<http://purl.obolibrary.org/obo/FYPO_0000900>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000900> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000909> (<http://purl.obolibrary.org/obo/FYPO_0000909>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000909> <http://purl.obolibrary.org/obo/FYPO_0002957>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000911> (<http://purl.obolibrary.org/obo/FYPO_0000911>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000911> <http://purl.obolibrary.org/obo/FYPO_0001322>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000911> <http://purl.obolibrary.org/obo/FYPO_0002403>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000934> (<http://purl.obolibrary.org/obo/FYPO_0000934>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000934> <http://purl.obolibrary.org/obo/FYPO_0000931>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000938> (<http://purl.obolibrary.org/obo/FYPO_0000938>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000938> <http://purl.obolibrary.org/obo/FYPO_0000930>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000938> <http://purl.obolibrary.org/obo/FYPO_0000934>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000938> <http://purl.obolibrary.org/obo/FYPO_0000935>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000944> (<http://purl.obolibrary.org/obo/FYPO_0000944>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000944> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000944> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000943>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000944> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000945> (<http://purl.obolibrary.org/obo/FYPO_0000945>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000945> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000945> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000946> (<http://purl.obolibrary.org/obo/FYPO_0000946>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000947> (<http://purl.obolibrary.org/obo/FYPO_0000947>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000947> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000129>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000947> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000948> (<http://purl.obolibrary.org/obo/FYPO_0000948>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000948> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000129>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000948> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000949> (<http://purl.obolibrary.org/obo/FYPO_0000949>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000949> <http://purl.obolibrary.org/obo/FYPO_0004639>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000949> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000272>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000950> (<http://purl.obolibrary.org/obo/FYPO_0000950>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000950> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000950> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000950> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000951> (<http://purl.obolibrary.org/obo/FYPO_0000951>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000951> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000951> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000951> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000952> (<http://purl.obolibrary.org/obo/FYPO_0000952>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000952> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000966> (<http://purl.obolibrary.org/obo/FYPO_0000966>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000966> <http://purl.obolibrary.org/obo/FYPO_0005310>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000967> (<http://purl.obolibrary.org/obo/FYPO_0000967>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000967> <http://purl.obolibrary.org/obo/FYPO_0001458>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0000998> (<http://purl.obolibrary.org/obo/FYPO_0000998>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0000998> <http://purl.obolibrary.org/obo/FYPO_0006633>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001000> (<http://purl.obolibrary.org/obo/FYPO_0001000>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001000> <http://purl.obolibrary.org/obo/FYPO_0000711>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001001> (<http://purl.obolibrary.org/obo/FYPO_0001001>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001001> <http://purl.obolibrary.org/obo/FYPO_0001151>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001003> (<http://purl.obolibrary.org/obo/FYPO_0001003>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001003> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002787>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002790>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001003> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006053>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001006> (<http://purl.obolibrary.org/obo/FYPO_0001006>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000779>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001009> (<http://purl.obolibrary.org/obo/FYPO_0001009>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001009> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001008>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001010> (<http://purl.obolibrary.org/obo/FYPO_0001010>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001010> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001011>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001011> (<http://purl.obolibrary.org/obo/FYPO_0001011>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001011> <http://purl.obolibrary.org/obo/FYPO_0003684>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001018> (<http://purl.obolibrary.org/obo/FYPO_0001018>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001018> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001391>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001025> (<http://purl.obolibrary.org/obo/FYPO_0001025>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001025> <http://purl.obolibrary.org/obo/FYPO_0006915>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001047> (<http://purl.obolibrary.org/obo/FYPO_0001047>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001047> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000337>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001049> (<http://purl.obolibrary.org/obo/FYPO_0001049>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> <http://purl.obolibrary.org/obo/FYPO_0002273>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000951>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001050> (<http://purl.obolibrary.org/obo/FYPO_0001050>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> <http://purl.obolibrary.org/obo/FYPO_0002199>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001051> (<http://purl.obolibrary.org/obo/FYPO_0001051>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> <http://purl.obolibrary.org/obo/FYPO_0002273>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001490>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001052> (<http://purl.obolibrary.org/obo/FYPO_0001052>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000951>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001052> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003165>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001053> (<http://purl.obolibrary.org/obo/FYPO_0001053>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001053> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003165>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001054> (<http://purl.obolibrary.org/obo/FYPO_0001054>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001490>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003165>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001059> (<http://purl.obolibrary.org/obo/FYPO_0001059>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001059> <http://purl.obolibrary.org/obo/FYPO_0001334>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001063> (<http://purl.obolibrary.org/obo/FYPO_0001063>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001063> <http://purl.obolibrary.org/obo/FYPO_0001334>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001071> (<http://purl.obolibrary.org/obo/FYPO_0001071>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001071> <http://purl.obolibrary.org/obo/FYPO_0001319>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001071> <http://purl.obolibrary.org/obo/FYPO_0001336>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001112> (<http://purl.obolibrary.org/obo/FYPO_0001112>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001112> <http://purl.obolibrary.org/obo/FYPO_0000711>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001118> (<http://purl.obolibrary.org/obo/FYPO_0001118>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001118> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001121> (<http://purl.obolibrary.org/obo/FYPO_0001121>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001121> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001121> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001121> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001122> (<http://purl.obolibrary.org/obo/FYPO_0001122>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001122> <http://purl.obolibrary.org/obo/FYPO_0000017>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001123> (<http://purl.obolibrary.org/obo/FYPO_0001123>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001123> <http://purl.obolibrary.org/obo/FYPO_0002467>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001152> (<http://purl.obolibrary.org/obo/FYPO_0001152>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001152> <http://purl.obolibrary.org/obo/FYPO_0004139>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001165> (<http://purl.obolibrary.org/obo/FYPO_0001165>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001165> <http://purl.obolibrary.org/obo/FYPO_0001321>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001170> (<http://purl.obolibrary.org/obo/FYPO_0001170>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001170> <http://purl.obolibrary.org/obo/FYPO_0001648>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001211> (<http://purl.obolibrary.org/obo/FYPO_0001211>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001211> <http://purl.obolibrary.org/obo/FYPO_0001289>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001219> (<http://purl.obolibrary.org/obo/FYPO_0001219>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001219> <http://purl.obolibrary.org/obo/FYPO_0004139>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001223> (<http://purl.obolibrary.org/obo/FYPO_0001223>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001223> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001226> (<http://purl.obolibrary.org/obo/FYPO_0001226>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000339>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001226> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001228> (<http://purl.obolibrary.org/obo/FYPO_0001228>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001228> <http://purl.obolibrary.org/obo/FYPO_0001102>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001248> (<http://purl.obolibrary.org/obo/FYPO_0001248>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001248> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001252> (<http://purl.obolibrary.org/obo/FYPO_0001252>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001253> (<http://purl.obolibrary.org/obo/FYPO_0001253>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001253> <http://purl.obolibrary.org/obo/FYPO_0000223>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001283> (<http://purl.obolibrary.org/obo/FYPO_0001283>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001283> <http://purl.obolibrary.org/obo/FYPO_0004139>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001322> (<http://purl.obolibrary.org/obo/FYPO_0001322>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001322> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001332> (<http://purl.obolibrary.org/obo/FYPO_0001332>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001332> <http://purl.obolibrary.org/obo/FYPO_0005044>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001345> (<http://purl.obolibrary.org/obo/FYPO_0001345>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001345> <http://purl.obolibrary.org/obo/FYPO_0001363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001369> (<http://purl.obolibrary.org/obo/FYPO_0001369>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001369> <http://purl.obolibrary.org/obo/FYPO_0004736>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001369> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000033>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001385> (<http://purl.obolibrary.org/obo/FYPO_0001385>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000444>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001389> (<http://purl.obolibrary.org/obo/FYPO_0001389>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001389> <http://purl.obolibrary.org/obo/FYPO_0001337>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001392> (<http://purl.obolibrary.org/obo/FYPO_0001392>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001392> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001399> (<http://purl.obolibrary.org/obo/FYPO_0001399>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001399> <http://purl.obolibrary.org/obo/FYPO_0004568>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001417> (<http://purl.obolibrary.org/obo/FYPO_0001417>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001417> <http://purl.obolibrary.org/obo/FYPO_0004315>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001425> (<http://purl.obolibrary.org/obo/FYPO_0001425>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000158>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001426> (<http://purl.obolibrary.org/obo/FYPO_0001426>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000158>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001427> (<http://purl.obolibrary.org/obo/FYPO_0001427>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000158>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001429> (<http://purl.obolibrary.org/obo/FYPO_0001429>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001429> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001429> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001429> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000025>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001430> (<http://purl.obolibrary.org/obo/FYPO_0001430>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001974>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001441> (<http://purl.obolibrary.org/obo/FYPO_0001441>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001441> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001489> (<http://purl.obolibrary.org/obo/FYPO_0001489>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001489> <http://purl.obolibrary.org/obo/FYPO_0001321>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001490> (<http://purl.obolibrary.org/obo/FYPO_0001490>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001490> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001490> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001491> (<http://purl.obolibrary.org/obo/FYPO_0001491>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001491> <http://purl.obolibrary.org/obo/FYPO_0001321>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001492> (<http://purl.obolibrary.org/obo/FYPO_0001492>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001492> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001493> (<http://purl.obolibrary.org/obo/FYPO_0001493>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001493> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001494> (<http://purl.obolibrary.org/obo/FYPO_0001494>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001495> (<http://purl.obolibrary.org/obo/FYPO_0001495>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001496> (<http://purl.obolibrary.org/obo/FYPO_0001496>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001497> (<http://purl.obolibrary.org/obo/FYPO_0001497>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000837>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001497> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001510> (<http://purl.obolibrary.org/obo/FYPO_0001510>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001510> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001510> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001510> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001511> (<http://purl.obolibrary.org/obo/FYPO_0001511>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001512> (<http://purl.obolibrary.org/obo/FYPO_0001512>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001512> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001512> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001512> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001532> (<http://purl.obolibrary.org/obo/FYPO_0001532>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001532> <http://purl.obolibrary.org/obo/FYPO_0003246>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001553> (<http://purl.obolibrary.org/obo/FYPO_0001553>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001553> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001607> (<http://purl.obolibrary.org/obo/FYPO_0001607>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001607> <http://purl.obolibrary.org/obo/FYPO_0001613>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001608> (<http://purl.obolibrary.org/obo/FYPO_0001608>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001608> <http://purl.obolibrary.org/obo/FYPO_0001563>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001609> (<http://purl.obolibrary.org/obo/FYPO_0001609>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001609> <http://purl.obolibrary.org/obo/FYPO_0001564>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001610> (<http://purl.obolibrary.org/obo/FYPO_0001610>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001610> <http://purl.obolibrary.org/obo/FYPO_0001619>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001611> (<http://purl.obolibrary.org/obo/FYPO_0001611>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001611> <http://purl.obolibrary.org/obo/FYPO_0001562>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001612> (<http://purl.obolibrary.org/obo/FYPO_0001612>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001612> <http://purl.obolibrary.org/obo/FYPO_0001621>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001623> (<http://purl.obolibrary.org/obo/FYPO_0001623>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001623> <http://purl.obolibrary.org/obo/FYPO_0001635>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001625> (<http://purl.obolibrary.org/obo/FYPO_0001625>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001625> <http://purl.obolibrary.org/obo/FYPO_0001636>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001626> (<http://purl.obolibrary.org/obo/FYPO_0001626>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001626> <http://purl.obolibrary.org/obo/FYPO_0001637>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001627> (<http://purl.obolibrary.org/obo/FYPO_0001627>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001627> <http://purl.obolibrary.org/obo/FYPO_0001638>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001628> (<http://purl.obolibrary.org/obo/FYPO_0001628>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001628> <http://purl.obolibrary.org/obo/FYPO_0002746>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001629> (<http://purl.obolibrary.org/obo/FYPO_0001629>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001629> <http://purl.obolibrary.org/obo/FYPO_0001639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001631> (<http://purl.obolibrary.org/obo/FYPO_0001631>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001631> <http://purl.obolibrary.org/obo/FYPO_0001640>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001632> (<http://purl.obolibrary.org/obo/FYPO_0001632>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001632> <http://purl.obolibrary.org/obo/FYPO_0001641>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001633> (<http://purl.obolibrary.org/obo/FYPO_0001633>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001633> <http://purl.obolibrary.org/obo/FYPO_0001642>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001634> (<http://purl.obolibrary.org/obo/FYPO_0001634>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001634> <http://purl.obolibrary.org/obo/FYPO_0001643>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001646> (<http://purl.obolibrary.org/obo/FYPO_0001646>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001646> <http://purl.obolibrary.org/obo/FYPO_0000145>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001683> (<http://purl.obolibrary.org/obo/FYPO_0001683>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001683> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002018>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001703> (<http://purl.obolibrary.org/obo/FYPO_0001703>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001703> <http://purl.obolibrary.org/obo/FYPO_0001928>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001705> (<http://purl.obolibrary.org/obo/FYPO_0001705>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001705> <http://purl.obolibrary.org/obo/FYPO_0000968>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001712> (<http://purl.obolibrary.org/obo/FYPO_0001712>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001712> <http://purl.obolibrary.org/obo/FYPO_0006978>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001729> (<http://purl.obolibrary.org/obo/FYPO_0001729>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001729> <http://purl.obolibrary.org/obo/FYPO_0001726>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001731> (<http://purl.obolibrary.org/obo/FYPO_0001731>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001731> <http://purl.obolibrary.org/obo/FYPO_0001568>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001732> (<http://purl.obolibrary.org/obo/FYPO_0001732>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001732> <http://purl.obolibrary.org/obo/FYPO_0001727>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001733> (<http://purl.obolibrary.org/obo/FYPO_0001733>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001733> <http://purl.obolibrary.org/obo/FYPO_0001362>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001733> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001783> (<http://purl.obolibrary.org/obo/FYPO_0001783>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001783> <http://purl.obolibrary.org/obo/FYPO_0001321>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001783> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000832>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001783> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001782>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001796> (<http://purl.obolibrary.org/obo/FYPO_0001796>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001796> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000449>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001798> (<http://purl.obolibrary.org/obo/FYPO_0001798>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001798> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001324>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001852> (<http://purl.obolibrary.org/obo/FYPO_0001852>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001852> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002042>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001855> (<http://purl.obolibrary.org/obo/FYPO_0001855>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001855> <http://purl.obolibrary.org/obo/FYPO_0000290>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001855> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001861> (<http://purl.obolibrary.org/obo/FYPO_0001861>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001861> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000141>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001862> (<http://purl.obolibrary.org/obo/FYPO_0001862>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001862> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001877> (<http://purl.obolibrary.org/obo/FYPO_0001877>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001877> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001877> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001879>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001878> (<http://purl.obolibrary.org/obo/FYPO_0001878>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001878> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001878> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001878> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001879>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001914> (<http://purl.obolibrary.org/obo/FYPO_0001914>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001914> <http://purl.obolibrary.org/obo/FYPO_0000336>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001914> <http://purl.obolibrary.org/obo/FYPO_0000679>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001914> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001916> (<http://purl.obolibrary.org/obo/FYPO_0001916>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001916> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001916> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001916> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001917> (<http://purl.obolibrary.org/obo/FYPO_0001917>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001917> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001917> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001917> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001917> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001924> (<http://purl.obolibrary.org/obo/FYPO_0001924>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001924> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000407>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001930> (<http://purl.obolibrary.org/obo/FYPO_0001930>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001930> <http://purl.obolibrary.org/obo/FYPO_0001341>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001949> (<http://purl.obolibrary.org/obo/FYPO_0001949>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001949> <http://purl.obolibrary.org/obo/FYPO_0001198>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001953> (<http://purl.obolibrary.org/obo/FYPO_0001953>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001953> <http://purl.obolibrary.org/obo/FYPO_0001334>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001978> (<http://purl.obolibrary.org/obo/FYPO_0001978>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001978> <http://purl.obolibrary.org/obo/FYPO_0003607>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001985> (<http://purl.obolibrary.org/obo/FYPO_0001985>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001985> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/FYPO_0000001>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001992> (<http://purl.obolibrary.org/obo/FYPO_0001992>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001992> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001992> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000339>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001992> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001992> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001992> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001992> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000229>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0001994> (<http://purl.obolibrary.org/obo/FYPO_0001994>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
@@ -413,1395 +2841,4073 @@ SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<h
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001391>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0001994> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0002017>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002000> (<http://purl.obolibrary.org/obo/FYPO_0002000>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002069>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002014> (<http://purl.obolibrary.org/obo/FYPO_0002014>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002014> <http://purl.obolibrary.org/obo/FYPO_0003196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002017> (<http://purl.obolibrary.org/obo/FYPO_0002017>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002017> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001018>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002020> (<http://purl.obolibrary.org/obo/FYPO_0002020>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002020> <http://purl.obolibrary.org/obo/FYPO_0004139>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002023> (<http://purl.obolibrary.org/obo/FYPO_0002023>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000117>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002024> (<http://purl.obolibrary.org/obo/FYPO_0002024>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000417>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002025> (<http://purl.obolibrary.org/obo/FYPO_0002025>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002025> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002023>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002029> (<http://purl.obolibrary.org/obo/FYPO_0002029>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002029> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000033>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002031> (<http://purl.obolibrary.org/obo/FYPO_0002031>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0002030>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002038> (<http://purl.obolibrary.org/obo/FYPO_0002038>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002038> <http://purl.obolibrary.org/obo/FYPO_0001347>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002038> <http://purl.obolibrary.org/obo/FYPO_0001363>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002038> <http://purl.obolibrary.org/obo/FYPO_0004851>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002042> (<http://purl.obolibrary.org/obo/FYPO_0002042>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002042> <http://purl.obolibrary.org/obo/FYPO_0003196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002049> (<http://purl.obolibrary.org/obo/FYPO_0002049>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002049> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002050> (<http://purl.obolibrary.org/obo/FYPO_0002050>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002050> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002051> (<http://purl.obolibrary.org/obo/FYPO_0002051>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002051> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002066> (<http://purl.obolibrary.org/obo/FYPO_0002066>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002066> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002066> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002066> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002069> (<http://purl.obolibrary.org/obo/FYPO_0002069>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002069> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000517>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002070> (<http://purl.obolibrary.org/obo/FYPO_0002070>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002070> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001389>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002071> (<http://purl.obolibrary.org/obo/FYPO_0002071>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002071> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001338>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002072> (<http://purl.obolibrary.org/obo/FYPO_0002072>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002072> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000942>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002076> (<http://purl.obolibrary.org/obo/FYPO_0002076>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002076> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002076> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001406>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002076> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002076> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001919>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002083> (<http://purl.obolibrary.org/obo/FYPO_0002083>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000344>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002083> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002084> (<http://purl.obolibrary.org/obo/FYPO_0002084>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002084> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002084> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002084> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002086> (<http://purl.obolibrary.org/obo/FYPO_0002086>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002086> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0002089>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002092> (<http://purl.obolibrary.org/obo/FYPO_0002092>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002092> <http://purl.obolibrary.org/obo/FYPO_0006759>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002103> (<http://purl.obolibrary.org/obo/FYPO_0002103>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002103> <http://purl.obolibrary.org/obo/FYPO_0002452>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002105> (<http://purl.obolibrary.org/obo/FYPO_0002105>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002105> <http://purl.obolibrary.org/obo/FYPO_0002199>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002106> (<http://purl.obolibrary.org/obo/FYPO_0002106>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002107> (<http://purl.obolibrary.org/obo/FYPO_0002107>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002107> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002107> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002108> (<http://purl.obolibrary.org/obo/FYPO_0002108>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002108> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002108> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002108> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000124>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002109> (<http://purl.obolibrary.org/obo/FYPO_0002109>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002109> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002109> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002109> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000049>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002110> (<http://purl.obolibrary.org/obo/FYPO_0002110>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002110> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002110> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002111> (<http://purl.obolibrary.org/obo/FYPO_0002111>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002111> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002112> (<http://purl.obolibrary.org/obo/FYPO_0002112>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002112> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002112> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002113> (<http://purl.obolibrary.org/obo/FYPO_0002113>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002113> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002113> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002128> (<http://purl.obolibrary.org/obo/FYPO_0002128>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002136> (<http://purl.obolibrary.org/obo/FYPO_0002136>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002136> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002137> (<http://purl.obolibrary.org/obo/FYPO_0002137>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002137> <http://purl.obolibrary.org/obo/FYPO_0002136>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000825>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002138> (<http://purl.obolibrary.org/obo/FYPO_0002138>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002138> <http://purl.obolibrary.org/obo/FYPO_0002136>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001117>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002159> (<http://purl.obolibrary.org/obo/FYPO_0002159>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002159> <http://purl.obolibrary.org/obo/FYPO_0001967>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002167> (<http://purl.obolibrary.org/obo/FYPO_0002167>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002167> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002176> (<http://purl.obolibrary.org/obo/FYPO_0002176>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002176> <http://purl.obolibrary.org/obo/FYPO_0001321>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002176> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002187> (<http://purl.obolibrary.org/obo/FYPO_0002187>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002187> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002187> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002187> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002189> (<http://purl.obolibrary.org/obo/FYPO_0002189>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002189> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002189> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002189> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002190> (<http://purl.obolibrary.org/obo/FYPO_0002190>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002190> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002191> (<http://purl.obolibrary.org/obo/FYPO_0002191>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002193> (<http://purl.obolibrary.org/obo/FYPO_0002193>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001955>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002197> (<http://purl.obolibrary.org/obo/FYPO_0002197>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002197> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002199> (<http://purl.obolibrary.org/obo/FYPO_0002199>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001315>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002200> (<http://purl.obolibrary.org/obo/FYPO_0002200>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002200> <http://purl.obolibrary.org/obo/FYPO_0002452>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002200> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002207> (<http://purl.obolibrary.org/obo/FYPO_0002207>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002207> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000347>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002207> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002208> (<http://purl.obolibrary.org/obo/FYPO_0002208>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000347>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002208> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002215> (<http://purl.obolibrary.org/obo/FYPO_0002215>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002215> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002230> (<http://purl.obolibrary.org/obo/FYPO_0002230>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002230> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002240> (<http://purl.obolibrary.org/obo/FYPO_0002240>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002240> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002240> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002240> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002241> (<http://purl.obolibrary.org/obo/FYPO_0002241>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002241> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002241> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002241> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002242> (<http://purl.obolibrary.org/obo/FYPO_0002242>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002242> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002250> (<http://purl.obolibrary.org/obo/FYPO_0002250>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002250> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001581>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002251> (<http://purl.obolibrary.org/obo/FYPO_0002251>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002251> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002252> (<http://purl.obolibrary.org/obo/FYPO_0002252>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002252> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002253>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002258> (<http://purl.obolibrary.org/obo/FYPO_0002258>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002258> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002787>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002258> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002790>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002266> (<http://purl.obolibrary.org/obo/FYPO_0002266>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002266> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000174>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002273> (<http://purl.obolibrary.org/obo/FYPO_0002273>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002273> <http://purl.obolibrary.org/obo/FYPO_0001321>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002273> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001118>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002276> (<http://purl.obolibrary.org/obo/FYPO_0002276>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002276> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000835>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002277> (<http://purl.obolibrary.org/obo/FYPO_0002277>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002277> <http://purl.obolibrary.org/obo/FYPO_0002796>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001283>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002279> (<http://purl.obolibrary.org/obo/FYPO_0002279>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002279> <http://purl.obolibrary.org/obo/FYPO_0002411>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002282> (<http://purl.obolibrary.org/obo/FYPO_0002282>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002286> (<http://purl.obolibrary.org/obo/FYPO_0002286>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002286> <http://purl.obolibrary.org/obo/FYPO_0003198>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002303> (<http://purl.obolibrary.org/obo/FYPO_0002303>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002303> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000229>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002313> (<http://purl.obolibrary.org/obo/FYPO_0002313>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002313> <http://purl.obolibrary.org/obo/FYPO_0002321>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002318> (<http://purl.obolibrary.org/obo/FYPO_0002318>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002318> <http://purl.obolibrary.org/obo/FYPO_0002327>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002319> (<http://purl.obolibrary.org/obo/FYPO_0002319>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002319> <http://purl.obolibrary.org/obo/FYPO_0002327>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002321> (<http://purl.obolibrary.org/obo/FYPO_0002321>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002321> <http://purl.obolibrary.org/obo/FYPO_0002326>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002323> (<http://purl.obolibrary.org/obo/FYPO_0002323>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002323> <http://purl.obolibrary.org/obo/FYPO_0001289>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002324> (<http://purl.obolibrary.org/obo/FYPO_0002324>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002324> <http://purl.obolibrary.org/obo/FYPO_0002326>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002331> (<http://purl.obolibrary.org/obo/FYPO_0002331>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002331> <http://purl.obolibrary.org/obo/FYPO_0005225>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002337> (<http://purl.obolibrary.org/obo/FYPO_0002337>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002337> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002069>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002344> (<http://purl.obolibrary.org/obo/FYPO_0002344>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002344> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002345> (<http://purl.obolibrary.org/obo/FYPO_0002345>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002345> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002355> (<http://purl.obolibrary.org/obo/FYPO_0002355>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002355> <http://purl.obolibrary.org/obo/FYPO_0007373>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002374> (<http://purl.obolibrary.org/obo/FYPO_0002374>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002374> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000790>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002377> (<http://purl.obolibrary.org/obo/FYPO_0002377>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002377> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002377> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002377> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002380> (<http://purl.obolibrary.org/obo/FYPO_0002380>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002380> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002380> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002381> (<http://purl.obolibrary.org/obo/FYPO_0002381>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002381> <http://purl.obolibrary.org/obo/FYPO_0002363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002382> (<http://purl.obolibrary.org/obo/FYPO_0002382>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002382> <http://purl.obolibrary.org/obo/FYPO_0002365>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002395> (<http://purl.obolibrary.org/obo/FYPO_0002395>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002395> <http://purl.obolibrary.org/obo/FYPO_0002386>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002397> (<http://purl.obolibrary.org/obo/FYPO_0002397>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002397> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000802>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002398> (<http://purl.obolibrary.org/obo/FYPO_0002398>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002398> <http://purl.obolibrary.org/obo/FYPO_0001322>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002398> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000801>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002399> (<http://purl.obolibrary.org/obo/FYPO_0002399>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002399> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000054>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002401> (<http://purl.obolibrary.org/obo/FYPO_0002401>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002401> <http://purl.obolibrary.org/obo/FYPO_0004315>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002402> (<http://purl.obolibrary.org/obo/FYPO_0002402>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002402> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002405> (<http://purl.obolibrary.org/obo/FYPO_0002405>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002405> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002406> (<http://purl.obolibrary.org/obo/FYPO_0002406>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002406> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002406> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002406> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002406> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002410> (<http://purl.obolibrary.org/obo/FYPO_0002410>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002410> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001581>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002411> (<http://purl.obolibrary.org/obo/FYPO_0002411>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002411> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002414> (<http://purl.obolibrary.org/obo/FYPO_0002414>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002414> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002414> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002415> (<http://purl.obolibrary.org/obo/FYPO_0002415>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002415> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002415> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002415> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002421> (<http://purl.obolibrary.org/obo/FYPO_0002421>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002421> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002423> (<http://purl.obolibrary.org/obo/FYPO_0002423>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002423> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002427> (<http://purl.obolibrary.org/obo/FYPO_0002427>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002427> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002429> (<http://purl.obolibrary.org/obo/FYPO_0002429>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002429> <http://purl.obolibrary.org/obo/FYPO_0002199>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002438> (<http://purl.obolibrary.org/obo/FYPO_0002438>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002438> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002438> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002434>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002438> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002436>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002439> (<http://purl.obolibrary.org/obo/FYPO_0002439>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002439> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002434>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002439> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002436>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002439> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002437>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002451> (<http://purl.obolibrary.org/obo/FYPO_0002451>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002451> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002451> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002451> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002452> (<http://purl.obolibrary.org/obo/FYPO_0002452>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002452> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002456> (<http://purl.obolibrary.org/obo/FYPO_0002456>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002456> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002455>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002457> (<http://purl.obolibrary.org/obo/FYPO_0002457>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002457> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002455>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002459> (<http://purl.obolibrary.org/obo/FYPO_0002459>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002459> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002460> (<http://purl.obolibrary.org/obo/FYPO_0002460>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002460> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002462> (<http://purl.obolibrary.org/obo/FYPO_0002462>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002462> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002463> (<http://purl.obolibrary.org/obo/FYPO_0002463>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002476> (<http://purl.obolibrary.org/obo/FYPO_0002476>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001581>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002478> (<http://purl.obolibrary.org/obo/FYPO_0002478>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002478> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002478> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002478> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001581>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002479> (<http://purl.obolibrary.org/obo/FYPO_0002479>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002479> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002482> (<http://purl.obolibrary.org/obo/FYPO_0002482>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002482> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002482> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002483> (<http://purl.obolibrary.org/obo/FYPO_0002483>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002483> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000014>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002483> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002483> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002488> (<http://purl.obolibrary.org/obo/FYPO_0002488>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002488> <http://purl.obolibrary.org/obo/FYPO_0000002>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002516> (<http://purl.obolibrary.org/obo/FYPO_0002516>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002516> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001046>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002517> (<http://purl.obolibrary.org/obo/FYPO_0002517>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002517> <http://purl.obolibrary.org/obo/FYPO_0000011>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002517> <http://purl.obolibrary.org/obo/FYPO_0001362>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002517> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001026>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002518> (<http://purl.obolibrary.org/obo/FYPO_0002518>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002518> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000827>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002519> (<http://purl.obolibrary.org/obo/FYPO_0002519>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002519> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002516>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002522> (<http://purl.obolibrary.org/obo/FYPO_0002522>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002522> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003119>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002525> (<http://purl.obolibrary.org/obo/FYPO_0002525>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002525> <http://purl.obolibrary.org/obo/FYPO_0001313>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002560> (<http://purl.obolibrary.org/obo/FYPO_0002560>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002560> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002564> (<http://purl.obolibrary.org/obo/FYPO_0002564>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002564> <http://purl.obolibrary.org/obo/FYPO_0002579>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002584> (<http://purl.obolibrary.org/obo/FYPO_0002584>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002584> <http://purl.obolibrary.org/obo/FYPO_0003423>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002585> (<http://purl.obolibrary.org/obo/FYPO_0002585>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002585> <http://purl.obolibrary.org/obo/FYPO_0003161>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002602> (<http://purl.obolibrary.org/obo/FYPO_0002602>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002602> <http://purl.obolibrary.org/obo/FYPO_0002598>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002603> (<http://purl.obolibrary.org/obo/FYPO_0002603>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002603> <http://purl.obolibrary.org/obo/FYPO_0002597>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002605> (<http://purl.obolibrary.org/obo/FYPO_0002605>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002605> <http://purl.obolibrary.org/obo/FYPO_0004112>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002606> (<http://purl.obolibrary.org/obo/FYPO_0002606>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002606> <http://purl.obolibrary.org/obo/FYPO_0004353>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002608> (<http://purl.obolibrary.org/obo/FYPO_0002608>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002608> <http://purl.obolibrary.org/obo/FYPO_0002596>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002609> (<http://purl.obolibrary.org/obo/FYPO_0002609>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002609> <http://purl.obolibrary.org/obo/FYPO_0002598>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002627> (<http://purl.obolibrary.org/obo/FYPO_0002627>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002627> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002629> (<http://purl.obolibrary.org/obo/FYPO_0002629>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002629> <http://purl.obolibrary.org/obo/FYPO_0001208>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002639> (<http://purl.obolibrary.org/obo/FYPO_0002639>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002639> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001778>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002655> (<http://purl.obolibrary.org/obo/FYPO_0002655>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002655> <http://purl.obolibrary.org/obo/FYPO_0004639>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002086>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002655> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002654>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002656> (<http://purl.obolibrary.org/obo/FYPO_0002656>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002656> <http://purl.obolibrary.org/obo/FYPO_0003591>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002660> (<http://purl.obolibrary.org/obo/FYPO_0002660>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002660> <http://purl.obolibrary.org/obo/FYPO_0001447>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002704> (<http://purl.obolibrary.org/obo/FYPO_0002704>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002704> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002715> (<http://purl.obolibrary.org/obo/FYPO_0002715>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002715> <http://purl.obolibrary.org/obo/FYPO_0001313>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002722> (<http://purl.obolibrary.org/obo/FYPO_0002722>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002722> <http://purl.obolibrary.org/obo/FYPO_0002829>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002732> (<http://purl.obolibrary.org/obo/FYPO_0002732>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002732> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002732> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002730>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002732> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002731>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002760> (<http://purl.obolibrary.org/obo/FYPO_0002760>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002760> <http://purl.obolibrary.org/obo/FYPO_0004088>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002762> (<http://purl.obolibrary.org/obo/FYPO_0002762>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002762> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002779> (<http://purl.obolibrary.org/obo/FYPO_0002779>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002779> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002780> (<http://purl.obolibrary.org/obo/FYPO_0002780>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002780> <http://purl.obolibrary.org/obo/FYPO_0001329>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002787> (<http://purl.obolibrary.org/obo/FYPO_0002787>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002787> <http://purl.obolibrary.org/obo/FYPO_0002257>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002788> (<http://purl.obolibrary.org/obo/FYPO_0002788>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002788> <http://purl.obolibrary.org/obo/FYPO_0000368>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002791> (<http://purl.obolibrary.org/obo/FYPO_0002791>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002791> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002787>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002791> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002790>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002791> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006053>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002792> (<http://purl.obolibrary.org/obo/FYPO_0002792>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002792> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002787>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002792> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002790>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002792> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006053>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002792> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0004483>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002793> (<http://purl.obolibrary.org/obo/FYPO_0002793>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002793> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002795> (<http://purl.obolibrary.org/obo/FYPO_0002795>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002795> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002795> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000123>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002795> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002793>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002797> (<http://purl.obolibrary.org/obo/FYPO_0002797>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002797> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000836>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002798> (<http://purl.obolibrary.org/obo/FYPO_0002798>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002798> <http://purl.obolibrary.org/obo/FYPO_0002796>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002798> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001219>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002800> (<http://purl.obolibrary.org/obo/FYPO_0002800>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002800> <http://purl.obolibrary.org/obo/FYPO_0000859>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002816> (<http://purl.obolibrary.org/obo/FYPO_0002816>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002816> <http://purl.obolibrary.org/obo/FYPO_0001493>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002818> (<http://purl.obolibrary.org/obo/FYPO_0002818>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002818> <http://purl.obolibrary.org/obo/FYPO_0004315>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002820> (<http://purl.obolibrary.org/obo/FYPO_0002820>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002820> <http://purl.obolibrary.org/obo/FYPO_0007375>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002821> (<http://purl.obolibrary.org/obo/FYPO_0002821>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002821> <http://purl.obolibrary.org/obo/FYPO_0000940>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002822> (<http://purl.obolibrary.org/obo/FYPO_0002822>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002822> <http://purl.obolibrary.org/obo/FYPO_0000940>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002835> (<http://purl.obolibrary.org/obo/FYPO_0002835>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002835> <http://purl.obolibrary.org/obo/FYPO_0006076>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002842> (<http://purl.obolibrary.org/obo/FYPO_0002842>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002842> <http://purl.obolibrary.org/obo/FYPO_0002839>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002843> (<http://purl.obolibrary.org/obo/FYPO_0002843>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002843> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0002529>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002845> (<http://purl.obolibrary.org/obo/FYPO_0002845>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002845> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002845> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002845> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002845> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002847> (<http://purl.obolibrary.org/obo/FYPO_0002847>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002847> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002858> (<http://purl.obolibrary.org/obo/FYPO_0002858>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002858> <http://purl.obolibrary.org/obo/FYPO_0001194>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002873> (<http://purl.obolibrary.org/obo/FYPO_0002873>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002873> <http://purl.obolibrary.org/obo/FYPO_0001313>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002875> (<http://purl.obolibrary.org/obo/FYPO_0002875>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002875> <http://purl.obolibrary.org/obo/FYPO_0005502>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002875> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001890>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002876> (<http://purl.obolibrary.org/obo/FYPO_0002876>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002876> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000826>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002879> (<http://purl.obolibrary.org/obo/FYPO_0002879>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002879> <http://purl.obolibrary.org/obo/FYPO_0003120>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002889> (<http://purl.obolibrary.org/obo/FYPO_0002889>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002889> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002889> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002889> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002455>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002903> (<http://purl.obolibrary.org/obo/FYPO_0002903>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002903> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002903> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002904> (<http://purl.obolibrary.org/obo/FYPO_0002904>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002904> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002904> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002911> (<http://purl.obolibrary.org/obo/FYPO_0002911>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002911> <http://purl.obolibrary.org/obo/FYPO_0002415>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002912> (<http://purl.obolibrary.org/obo/FYPO_0002912>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002912> <http://purl.obolibrary.org/obo/FYPO_0001493>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002913> (<http://purl.obolibrary.org/obo/FYPO_0002913>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002913> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003557>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002941> (<http://purl.obolibrary.org/obo/FYPO_0002941>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002941> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002941> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000025>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002941> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001955>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002943> (<http://purl.obolibrary.org/obo/FYPO_0002943>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002943> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000025>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002943> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001955>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002945> (<http://purl.obolibrary.org/obo/FYPO_0002945>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002945> <http://purl.obolibrary.org/obo/FYPO_0000824>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002970> (<http://purl.obolibrary.org/obo/FYPO_0002970>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002970> <http://purl.obolibrary.org/obo/FYPO_0002969>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002978> (<http://purl.obolibrary.org/obo/FYPO_0002978>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002978> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002987> (<http://purl.obolibrary.org/obo/FYPO_0002987>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002987> <http://purl.obolibrary.org/obo/FYPO_0002273>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002987> <http://purl.obolibrary.org/obo/FYPO_0004257>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002991> (<http://purl.obolibrary.org/obo/FYPO_0002991>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002991> <http://purl.obolibrary.org/obo/FYPO_0000398>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002992> (<http://purl.obolibrary.org/obo/FYPO_0002992>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002992> <http://purl.obolibrary.org/obo/FYPO_0000398>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0002994> (<http://purl.obolibrary.org/obo/FYPO_0002994>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0002994> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003002> (<http://purl.obolibrary.org/obo/FYPO_0003002>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003002> <http://purl.obolibrary.org/obo/FYPO_0000450>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003003> (<http://purl.obolibrary.org/obo/FYPO_0003003>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003003> <http://purl.obolibrary.org/obo/FYPO_0000451>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003004> (<http://purl.obolibrary.org/obo/FYPO_0003004>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003004> <http://purl.obolibrary.org/obo/FYPO_0001330>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003005> (<http://purl.obolibrary.org/obo/FYPO_0003005>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003005> <http://purl.obolibrary.org/obo/FYPO_0002845>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003005> <http://purl.obolibrary.org/obo/FYPO_0004494>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003009> (<http://purl.obolibrary.org/obo/FYPO_0003009>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003009> <http://purl.obolibrary.org/obo/FYPO_0002840>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003010> (<http://purl.obolibrary.org/obo/FYPO_0003010>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003010> <http://purl.obolibrary.org/obo/FYPO_0004656>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003024> (<http://purl.obolibrary.org/obo/FYPO_0003024>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/FYPO_0000051>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003037> (<http://purl.obolibrary.org/obo/FYPO_0003037>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003037> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/FYPO_0000002>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003048> (<http://purl.obolibrary.org/obo/FYPO_0003048>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003048> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000290>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003053> (<http://purl.obolibrary.org/obo/FYPO_0003053>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003053> <http://purl.obolibrary.org/obo/FYPO_0003052>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003054> (<http://purl.obolibrary.org/obo/FYPO_0003054>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003054> <http://purl.obolibrary.org/obo/FYPO_0003052>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003055> (<http://purl.obolibrary.org/obo/FYPO_0003055>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003055> <http://purl.obolibrary.org/obo/FYPO_0003052>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003056> (<http://purl.obolibrary.org/obo/FYPO_0003056>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003056> <http://purl.obolibrary.org/obo/FYPO_0007316>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003061> (<http://purl.obolibrary.org/obo/FYPO_0003061>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003061> <http://purl.obolibrary.org/obo/FYPO_0000051>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003068> (<http://purl.obolibrary.org/obo/FYPO_0003068>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003068> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003079> (<http://purl.obolibrary.org/obo/FYPO_0003079>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003079> <http://purl.obolibrary.org/obo/FYPO_0001334>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003079> <http://purl.obolibrary.org/obo/FYPO_0001346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003088> (<http://purl.obolibrary.org/obo/FYPO_0003088>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003088> <http://purl.obolibrary.org/obo/FYPO_0001334>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003088> <http://purl.obolibrary.org/obo/FYPO_0001346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003096> (<http://purl.obolibrary.org/obo/FYPO_0003096>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003096> <http://purl.obolibrary.org/obo/FYPO_0000872>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003101> (<http://purl.obolibrary.org/obo/FYPO_0003101>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003101> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003102> (<http://purl.obolibrary.org/obo/FYPO_0003102>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003102> <http://purl.obolibrary.org/obo/FYPO_0000871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003114> (<http://purl.obolibrary.org/obo/FYPO_0003114>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003114> <http://purl.obolibrary.org/obo/FYPO_0003004>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003117> (<http://purl.obolibrary.org/obo/FYPO_0003117>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003117> <http://purl.obolibrary.org/obo/FYPO_0003004>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003119> (<http://purl.obolibrary.org/obo/FYPO_0003119>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003119> <http://purl.obolibrary.org/obo/FYPO_0000911>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003122> (<http://purl.obolibrary.org/obo/FYPO_0003122>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003122> <http://purl.obolibrary.org/obo/FYPO_0003298>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003124> (<http://purl.obolibrary.org/obo/FYPO_0003124>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003124> <http://purl.obolibrary.org/obo/FYPO_0001797>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003127> (<http://purl.obolibrary.org/obo/FYPO_0003127>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003127> <http://purl.obolibrary.org/obo/FYPO_0002780>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003128> (<http://purl.obolibrary.org/obo/FYPO_0003128>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000608>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003128> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003130> (<http://purl.obolibrary.org/obo/FYPO_0003130>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003130> <http://purl.obolibrary.org/obo/FYPO_0000828>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003133> (<http://purl.obolibrary.org/obo/FYPO_0003133>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003133> <http://purl.obolibrary.org/obo/FYPO_0001209>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003133> <http://purl.obolibrary.org/obo/FYPO_0002265>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003138> (<http://purl.obolibrary.org/obo/FYPO_0003138>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000580>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003159> (<http://purl.obolibrary.org/obo/FYPO_0003159>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003159> <http://purl.obolibrary.org/obo/FYPO_0006705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003165> (<http://purl.obolibrary.org/obo/FYPO_0003165>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> <http://purl.obolibrary.org/obo/FYPO_0001047>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001204>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003171> (<http://purl.obolibrary.org/obo/FYPO_0003171>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003171> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003171> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002888>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003185> (<http://purl.obolibrary.org/obo/FYPO_0003185>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003185> <http://purl.obolibrary.org/obo/FYPO_0003184>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003192> (<http://purl.obolibrary.org/obo/FYPO_0003192>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003192> <http://purl.obolibrary.org/obo/FYPO_0001424>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003193> (<http://purl.obolibrary.org/obo/FYPO_0003193>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003193> <http://purl.obolibrary.org/obo/FYPO_0000899>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003204> (<http://purl.obolibrary.org/obo/FYPO_0003204>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003204> <http://purl.obolibrary.org/obo/FYPO_0000949>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003205> (<http://purl.obolibrary.org/obo/FYPO_0003205>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003205> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003890>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003210> (<http://purl.obolibrary.org/obo/FYPO_0003210>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003210> <http://purl.obolibrary.org/obo/FYPO_0002455>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000339>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003210> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001390>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003213> (<http://purl.obolibrary.org/obo/FYPO_0003213>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003213> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003440>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003225> (<http://purl.obolibrary.org/obo/FYPO_0003225>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003225> <http://purl.obolibrary.org/obo/FYPO_0000899>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003225> <http://purl.obolibrary.org/obo/FYPO_0001215>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003230> (<http://purl.obolibrary.org/obo/FYPO_0003230>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003230> <http://purl.obolibrary.org/obo/FYPO_0000872>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003231> (<http://purl.obolibrary.org/obo/FYPO_0003231>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003231> <http://purl.obolibrary.org/obo/FYPO_0000872>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003233> (<http://purl.obolibrary.org/obo/FYPO_0003233>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003233> <http://purl.obolibrary.org/obo/FYPO_0003232>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003234> (<http://purl.obolibrary.org/obo/FYPO_0003234>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003234> <http://purl.obolibrary.org/obo/FYPO_0003232>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003241> (<http://purl.obolibrary.org/obo/FYPO_0003241>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003241> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0004321>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003245> (<http://purl.obolibrary.org/obo/FYPO_0003245>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003245> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000417>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003277> (<http://purl.obolibrary.org/obo/FYPO_0003277>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003277> <http://purl.obolibrary.org/obo/FYPO_0003269>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003278> (<http://purl.obolibrary.org/obo/FYPO_0003278>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003278> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000813>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003280> (<http://purl.obolibrary.org/obo/FYPO_0003280>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003280> <http://purl.obolibrary.org/obo/FYPO_0003197>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003286> (<http://purl.obolibrary.org/obo/FYPO_0003286>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003286> <http://purl.obolibrary.org/obo/FYPO_0001363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003290> (<http://purl.obolibrary.org/obo/FYPO_0003290>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003290> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001910>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003297> (<http://purl.obolibrary.org/obo/FYPO_0003297>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003297> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003305> (<http://purl.obolibrary.org/obo/FYPO_0003305>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003305> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003304>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003313> (<http://purl.obolibrary.org/obo/FYPO_0003313>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003313> <http://purl.obolibrary.org/obo/FYPO_0004255>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003327> (<http://purl.obolibrary.org/obo/FYPO_0003327>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003327> <http://purl.obolibrary.org/obo/FYPO_0003625>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003327> <http://purl.obolibrary.org/obo/FYPO_0006101>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003328> (<http://purl.obolibrary.org/obo/FYPO_0003328>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003328> <http://purl.obolibrary.org/obo/FYPO_0006101>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003329> (<http://purl.obolibrary.org/obo/FYPO_0003329>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003329> <http://purl.obolibrary.org/obo/FYPO_0001585>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003333> (<http://purl.obolibrary.org/obo/FYPO_0003333>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003333> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000224>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003333> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003342> (<http://purl.obolibrary.org/obo/FYPO_0003342>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003342> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003342> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000017>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003342> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003341>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003352> (<http://purl.obolibrary.org/obo/FYPO_0003352>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003352> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000470>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003363> (<http://purl.obolibrary.org/obo/FYPO_0003363>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003363> <http://purl.obolibrary.org/obo/FYPO_0000628>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003369> (<http://purl.obolibrary.org/obo/FYPO_0003369>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003369> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003389> (<http://purl.obolibrary.org/obo/FYPO_0003389>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003389> <http://purl.obolibrary.org/obo/FYPO_0001492>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003389> <http://purl.obolibrary.org/obo/FYPO_0002402>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003402> (<http://purl.obolibrary.org/obo/FYPO_0003402>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003402> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003413> (<http://purl.obolibrary.org/obo/FYPO_0003413>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003413> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003413> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003413> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003413> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003415> (<http://purl.obolibrary.org/obo/FYPO_0003415>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003415> <http://purl.obolibrary.org/obo/FYPO_0002365>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003423> (<http://purl.obolibrary.org/obo/FYPO_0003423>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003423> <http://purl.obolibrary.org/obo/FYPO_0004958>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003424> (<http://purl.obolibrary.org/obo/FYPO_0003424>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003424> <http://purl.obolibrary.org/obo/FYPO_0004958>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003429> (<http://purl.obolibrary.org/obo/FYPO_0003429>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003429> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003429> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003430>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003429> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006103>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003430> (<http://purl.obolibrary.org/obo/FYPO_0003430>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003430> <http://purl.obolibrary.org/obo/FYPO_0004315>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003445> (<http://purl.obolibrary.org/obo/FYPO_0003445>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003445> <http://purl.obolibrary.org/obo/FYPO_0002900>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003448> (<http://purl.obolibrary.org/obo/FYPO_0003448>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001581>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003449> (<http://purl.obolibrary.org/obo/FYPO_0003449>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003449> <http://purl.obolibrary.org/obo/FYPO_0005097>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003452> (<http://purl.obolibrary.org/obo/FYPO_0003452>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003452> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003452> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001370>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003468> (<http://purl.obolibrary.org/obo/FYPO_0003468>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003468> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003479> (<http://purl.obolibrary.org/obo/FYPO_0003479>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003479> <http://purl.obolibrary.org/obo/FYPO_0001334>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003481> (<http://purl.obolibrary.org/obo/FYPO_0003481>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003481> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000012>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003489> (<http://purl.obolibrary.org/obo/FYPO_0003489>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003489> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003498> (<http://purl.obolibrary.org/obo/FYPO_0003498>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003498> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001248>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003500> (<http://purl.obolibrary.org/obo/FYPO_0003500>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003500> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003501> (<http://purl.obolibrary.org/obo/FYPO_0003501>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003503>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003504> (<http://purl.obolibrary.org/obo/FYPO_0003504>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003504> <http://purl.obolibrary.org/obo/FYPO_0003278>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003532> (<http://purl.obolibrary.org/obo/FYPO_0003532>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003150>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003552> (<http://purl.obolibrary.org/obo/FYPO_0003552>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003552> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001890>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003553> (<http://purl.obolibrary.org/obo/FYPO_0003553>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003553> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000826>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003556> (<http://purl.obolibrary.org/obo/FYPO_0003556>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003556> <http://purl.obolibrary.org/obo/FYPO_0001347>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003556> <http://purl.obolibrary.org/obo/FYPO_0001363>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003556> <http://purl.obolibrary.org/obo/FYPO_0004851>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003557> (<http://purl.obolibrary.org/obo/FYPO_0003557>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003557> <http://purl.obolibrary.org/obo/FYPO_0005857>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003560> (<http://purl.obolibrary.org/obo/FYPO_0003560>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003560> <http://purl.obolibrary.org/obo/FYPO_0000335>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003561> (<http://purl.obolibrary.org/obo/FYPO_0003561>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003561> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003570> (<http://purl.obolibrary.org/obo/FYPO_0003570>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003570> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003571> (<http://purl.obolibrary.org/obo/FYPO_0003571>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003571> <http://purl.obolibrary.org/obo/FYPO_0000872>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003572> (<http://purl.obolibrary.org/obo/FYPO_0003572>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003572> <http://purl.obolibrary.org/obo/FYPO_0000872>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003586> (<http://purl.obolibrary.org/obo/FYPO_0003586>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003586> <http://purl.obolibrary.org/obo/FYPO_0001346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003591> (<http://purl.obolibrary.org/obo/FYPO_0003591>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003591> <http://purl.obolibrary.org/obo/FYPO_0000704>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003592> (<http://purl.obolibrary.org/obo/FYPO_0003592>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003592> <http://purl.obolibrary.org/obo/FYPO_0001571>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003593> (<http://purl.obolibrary.org/obo/FYPO_0003593>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003593> <http://purl.obolibrary.org/obo/FYPO_0000544>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003593> <http://purl.obolibrary.org/obo/FYPO_0003585>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003595> (<http://purl.obolibrary.org/obo/FYPO_0003595>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003595> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003610> (<http://purl.obolibrary.org/obo/FYPO_0003610>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003610> <http://purl.obolibrary.org/obo/FYPO_0002459>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003633> (<http://purl.obolibrary.org/obo/FYPO_0003633>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003633> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003634> (<http://purl.obolibrary.org/obo/FYPO_0003634>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003634> <http://purl.obolibrary.org/obo/FYPO_0001645>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003635> (<http://purl.obolibrary.org/obo/FYPO_0003635>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003635> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003636> (<http://purl.obolibrary.org/obo/FYPO_0003636>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003636> <http://purl.obolibrary.org/obo/FYPO_0001645>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003647> (<http://purl.obolibrary.org/obo/FYPO_0003647>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003647> <http://purl.obolibrary.org/obo/FYPO_0005973>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003653> (<http://purl.obolibrary.org/obo/FYPO_0003653>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003653> <http://purl.obolibrary.org/obo/FYPO_0001855>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003677> (<http://purl.obolibrary.org/obo/FYPO_0003677>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003677> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003677> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003677> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003677> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003682> (<http://purl.obolibrary.org/obo/FYPO_0003682>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003682> <http://purl.obolibrary.org/obo/FYPO_0002024>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003685> (<http://purl.obolibrary.org/obo/FYPO_0003685>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003685> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003689> (<http://purl.obolibrary.org/obo/FYPO_0003689>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003693> (<http://purl.obolibrary.org/obo/FYPO_0003693>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003693> <http://purl.obolibrary.org/obo/FYPO_0001412>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003695> (<http://purl.obolibrary.org/obo/FYPO_0003695>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003695> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003696> (<http://purl.obolibrary.org/obo/FYPO_0003696>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003696> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003700> (<http://purl.obolibrary.org/obo/FYPO_0003700>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003700> <http://purl.obolibrary.org/obo/FYPO_0000825>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003710> (<http://purl.obolibrary.org/obo/FYPO_0003710>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003710> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003710> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001120>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003710> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003711> (<http://purl.obolibrary.org/obo/FYPO_0003711>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003711> <http://purl.obolibrary.org/obo/FYPO_0003684>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003714> (<http://purl.obolibrary.org/obo/FYPO_0003714>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003714> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003716> (<http://purl.obolibrary.org/obo/FYPO_0003716>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003716> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000784>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003728> (<http://purl.obolibrary.org/obo/FYPO_0003728>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003728> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003291>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003740> (<http://purl.obolibrary.org/obo/FYPO_0003740>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003740> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003744> (<http://purl.obolibrary.org/obo/FYPO_0003744>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003744> <http://purl.obolibrary.org/obo/FYPO_0005306>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003745> (<http://purl.obolibrary.org/obo/FYPO_0003745>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003745> <http://purl.obolibrary.org/obo/FYPO_0002363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003746> (<http://purl.obolibrary.org/obo/FYPO_0003746>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003746> <http://purl.obolibrary.org/obo/FYPO_0000871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003755> (<http://purl.obolibrary.org/obo/FYPO_0003755>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003755> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000052> <http://purl.obolibrary.org/obo/FYPO_0001320>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003756> (<http://purl.obolibrary.org/obo/FYPO_0003756>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003756> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001946>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003756> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003754>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003758> (<http://purl.obolibrary.org/obo/FYPO_0003758>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003758> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000444>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003759> (<http://purl.obolibrary.org/obo/FYPO_0003759>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003759> <http://purl.obolibrary.org/obo/FYPO_0001924>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003760> (<http://purl.obolibrary.org/obo/FYPO_0003760>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003760> <http://purl.obolibrary.org/obo/FYPO_0006430>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003763> (<http://purl.obolibrary.org/obo/FYPO_0003763>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003763> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003779> (<http://purl.obolibrary.org/obo/FYPO_0003779>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003779> <http://purl.obolibrary.org/obo/FYPO_0000769>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003779> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000815>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003780> (<http://purl.obolibrary.org/obo/FYPO_0003780>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003780> <http://purl.obolibrary.org/obo/FYPO_0003751>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003781> (<http://purl.obolibrary.org/obo/FYPO_0003781>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003781> <http://purl.obolibrary.org/obo/FYPO_0003751>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003782> (<http://purl.obolibrary.org/obo/FYPO_0003782>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003782> <http://purl.obolibrary.org/obo/FYPO_0000771>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003783> (<http://purl.obolibrary.org/obo/FYPO_0003783>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003783> <http://purl.obolibrary.org/obo/FYPO_0001337>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003785> (<http://purl.obolibrary.org/obo/FYPO_0003785>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003785> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003785> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003785> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003787> (<http://purl.obolibrary.org/obo/FYPO_0003787>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003787> <http://purl.obolibrary.org/obo/FYPO_0000733>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003788> (<http://purl.obolibrary.org/obo/FYPO_0003788>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003788> <http://purl.obolibrary.org/obo/FYPO_0003779>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003791> (<http://purl.obolibrary.org/obo/FYPO_0003791>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003791> <http://purl.obolibrary.org/obo/FYPO_0003346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003792> (<http://purl.obolibrary.org/obo/FYPO_0003792>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003792> <http://purl.obolibrary.org/obo/FYPO_0003346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003795> (<http://purl.obolibrary.org/obo/FYPO_0003795>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003795> <http://purl.obolibrary.org/obo/FYPO_0001196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003796> (<http://purl.obolibrary.org/obo/FYPO_0003796>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003796> <http://purl.obolibrary.org/obo/FYPO_0005229>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003802> (<http://purl.obolibrary.org/obo/FYPO_0003802>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003802> <http://purl.obolibrary.org/obo/FYPO_0005310>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003810> (<http://purl.obolibrary.org/obo/FYPO_0003810>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003810> <http://purl.obolibrary.org/obo/FYPO_0001322>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003810> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0007193>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003810> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0007194>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003814> (<http://purl.obolibrary.org/obo/FYPO_0003814>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003814> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0004241>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003825> (<http://purl.obolibrary.org/obo/FYPO_0003825>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003825> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003825> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003825> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003825> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002888>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003826> (<http://purl.obolibrary.org/obo/FYPO_0003826>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003826> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002888>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003829> (<http://purl.obolibrary.org/obo/FYPO_0003829>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003829> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000732>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003835> (<http://purl.obolibrary.org/obo/FYPO_0003835>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003835> <http://purl.obolibrary.org/obo/FYPO_0001071>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003844> (<http://purl.obolibrary.org/obo/FYPO_0003844>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003844> <http://purl.obolibrary.org/obo/FYPO_0001363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003873> (<http://purl.obolibrary.org/obo/FYPO_0003873>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003873> <http://purl.obolibrary.org/obo/FYPO_0002142>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003875> (<http://purl.obolibrary.org/obo/FYPO_0003875>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003875> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000012>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003875> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000608>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003875> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003875> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003876> (<http://purl.obolibrary.org/obo/FYPO_0003876>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003876> <http://purl.obolibrary.org/obo/FYPO_0001703>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003887> (<http://purl.obolibrary.org/obo/FYPO_0003887>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003887> <http://purl.obolibrary.org/obo/FYPO_0006393>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003904> (<http://purl.obolibrary.org/obo/FYPO_0003904>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003904> <http://purl.obolibrary.org/obo/FYPO_0001313>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003905> (<http://purl.obolibrary.org/obo/FYPO_0003905>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003905> <http://purl.obolibrary.org/obo/FYPO_0001313>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003915> (<http://purl.obolibrary.org/obo/FYPO_0003915>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003915> <http://purl.obolibrary.org/obo/FYPO_0004957>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003916> (<http://purl.obolibrary.org/obo/FYPO_0003916>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003916> <http://purl.obolibrary.org/obo/FYPO_0001333>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003916> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003931> (<http://purl.obolibrary.org/obo/FYPO_0003931>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003931> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003931> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003931> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003934> (<http://purl.obolibrary.org/obo/FYPO_0003934>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003934> <http://purl.obolibrary.org/obo/FYPO_0000860>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003935> (<http://purl.obolibrary.org/obo/FYPO_0003935>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003935> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003657>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003947> (<http://purl.obolibrary.org/obo/FYPO_0003947>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003947> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003950> (<http://purl.obolibrary.org/obo/FYPO_0003950>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003950> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003972> (<http://purl.obolibrary.org/obo/FYPO_0003972>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003972> <http://purl.obolibrary.org/obo/FYPO_0000186>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003975> (<http://purl.obolibrary.org/obo/FYPO_0003975>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003975> <http://purl.obolibrary.org/obo/FYPO_0001919>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003976> (<http://purl.obolibrary.org/obo/FYPO_0003976>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003976> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003976> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003976> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003975>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003977> (<http://purl.obolibrary.org/obo/FYPO_0003977>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003977> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003977> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003977> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003974>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003978> (<http://purl.obolibrary.org/obo/FYPO_0003978>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003978> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003978> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003974>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003978> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003975>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003979> (<http://purl.obolibrary.org/obo/FYPO_0003979>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003979> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003972>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003985> (<http://purl.obolibrary.org/obo/FYPO_0003985>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003985> <http://purl.obolibrary.org/obo/FYPO_0003984>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003986> (<http://purl.obolibrary.org/obo/FYPO_0003986>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003986> <http://purl.obolibrary.org/obo/FYPO_0003984>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003987> (<http://purl.obolibrary.org/obo/FYPO_0003987>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003987> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000790>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003988> (<http://purl.obolibrary.org/obo/FYPO_0003988>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003988> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000190>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0003989> (<http://purl.obolibrary.org/obo/FYPO_0003989>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003989> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003989> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0003989> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002731>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004002> (<http://purl.obolibrary.org/obo/FYPO_0004002>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004002> <http://purl.obolibrary.org/obo/FYPO_0000548>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004015> (<http://purl.obolibrary.org/obo/FYPO_0004015>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004015> <http://purl.obolibrary.org/obo/FYPO_0006034>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004022> (<http://purl.obolibrary.org/obo/FYPO_0004022>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004022> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004021>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004044> (<http://purl.obolibrary.org/obo/FYPO_0004044>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004043>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004045> (<http://purl.obolibrary.org/obo/FYPO_0004045>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004045> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004045> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004042>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004045> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004043>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004046> (<http://purl.obolibrary.org/obo/FYPO_0004046>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004046> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004046> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004042>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004046> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004043>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004047> (<http://purl.obolibrary.org/obo/FYPO_0004047>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004047> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004042>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004056> (<http://purl.obolibrary.org/obo/FYPO_0004056>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004056> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004061> (<http://purl.obolibrary.org/obo/FYPO_0004061>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004061> <http://purl.obolibrary.org/obo/FYPO_0004031>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004064> (<http://purl.obolibrary.org/obo/FYPO_0004064>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004064> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004066> (<http://purl.obolibrary.org/obo/FYPO_0004066>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004066> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004074> (<http://purl.obolibrary.org/obo/FYPO_0004074>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004074> <http://purl.obolibrary.org/obo/FYPO_0000532>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004074> <http://purl.obolibrary.org/obo/FYPO_0005097>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004076> (<http://purl.obolibrary.org/obo/FYPO_0004076>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004076> <http://purl.obolibrary.org/obo/FYPO_0000223>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004077> (<http://purl.obolibrary.org/obo/FYPO_0004077>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004077> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003378>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004086> (<http://purl.obolibrary.org/obo/FYPO_0004086>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004086> <http://purl.obolibrary.org/obo/FYPO_0004094>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004103> (<http://purl.obolibrary.org/obo/FYPO_0004103>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000129>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004104> (<http://purl.obolibrary.org/obo/FYPO_0004104>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004104> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000129>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004104> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004105> (<http://purl.obolibrary.org/obo/FYPO_0004105>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004105> <http://purl.obolibrary.org/obo/FYPO_0005449>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004106> (<http://purl.obolibrary.org/obo/FYPO_0004106>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004106> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004107> (<http://purl.obolibrary.org/obo/FYPO_0004107>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004107> <http://purl.obolibrary.org/obo/FYPO_0001325>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004113> (<http://purl.obolibrary.org/obo/FYPO_0004113>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004113> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004127> (<http://purl.obolibrary.org/obo/FYPO_0004127>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004127> <http://purl.obolibrary.org/obo/FYPO_0002367>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004137> (<http://purl.obolibrary.org/obo/FYPO_0004137>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004137> <http://purl.obolibrary.org/obo/FYPO_0000876>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004140> (<http://purl.obolibrary.org/obo/FYPO_0004140>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004140> <http://purl.obolibrary.org/obo/FYPO_0004139>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004141> (<http://purl.obolibrary.org/obo/FYPO_0004141>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004141> <http://purl.obolibrary.org/obo/FYPO_0004139>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004159> (<http://purl.obolibrary.org/obo/FYPO_0004159>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004159> <http://purl.obolibrary.org/obo/FYPO_0000051>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004170> (<http://purl.obolibrary.org/obo/FYPO_0004170>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004170> <http://purl.obolibrary.org/obo/FYPO_0007374>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004197> (<http://purl.obolibrary.org/obo/FYPO_0004197>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000837>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004197> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001919>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004198> (<http://purl.obolibrary.org/obo/FYPO_0004198>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004198> <http://purl.obolibrary.org/obo/FYPO_0000846>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004213> (<http://purl.obolibrary.org/obo/FYPO_0004213>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004213> <http://purl.obolibrary.org/obo/FYPO_0001362>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004213> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004226> (<http://purl.obolibrary.org/obo/FYPO_0004226>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004226> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004227> (<http://purl.obolibrary.org/obo/FYPO_0004227>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004227> <http://purl.obolibrary.org/obo/FYPO_0001645>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004236> (<http://purl.obolibrary.org/obo/FYPO_0004236>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004236> <http://purl.obolibrary.org/obo/FYPO_0003607>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004254> (<http://purl.obolibrary.org/obo/FYPO_0004254>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004254> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004255> (<http://purl.obolibrary.org/obo/FYPO_0004255>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004255> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004255> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004255> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004256> (<http://purl.obolibrary.org/obo/FYPO_0004256>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004256> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000224>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004256> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004257> (<http://purl.obolibrary.org/obo/FYPO_0004257>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004257> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004257> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004272> (<http://purl.obolibrary.org/obo/FYPO_0004272>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004272> <http://purl.obolibrary.org/obo/FYPO_0000679>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004295> (<http://purl.obolibrary.org/obo/FYPO_0004295>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004295> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004312> (<http://purl.obolibrary.org/obo/FYPO_0004312>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004312> <http://purl.obolibrary.org/obo/FYPO_0003744>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004313> (<http://purl.obolibrary.org/obo/FYPO_0004313>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004313> <http://purl.obolibrary.org/obo/FYPO_0006599>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004315> (<http://purl.obolibrary.org/obo/FYPO_0004315>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004315> <http://purl.obolibrary.org/obo/FYPO_0001322>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004315> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001350>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004326> (<http://purl.obolibrary.org/obo/FYPO_0004326>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004326> <http://purl.obolibrary.org/obo/FYPO_0000548>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004334> (<http://purl.obolibrary.org/obo/FYPO_0004334>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004334> <http://purl.obolibrary.org/obo/FYPO_0001130>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004339> (<http://purl.obolibrary.org/obo/FYPO_0004339>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004339> <http://purl.obolibrary.org/obo/FYPO_0001514>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004345> (<http://purl.obolibrary.org/obo/FYPO_0004345>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004345> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004346> (<http://purl.obolibrary.org/obo/FYPO_0004346>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004346> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004351> (<http://purl.obolibrary.org/obo/FYPO_0004351>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004351> <http://purl.obolibrary.org/obo/FYPO_0001130>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004352> (<http://purl.obolibrary.org/obo/FYPO_0004352>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004352> <http://purl.obolibrary.org/obo/FYPO_0001514>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004367> (<http://purl.obolibrary.org/obo/FYPO_0004367>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001399>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004369> (<http://purl.obolibrary.org/obo/FYPO_0004369>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004369> <http://purl.obolibrary.org/obo/FYPO_0002829>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004382> (<http://purl.obolibrary.org/obo/FYPO_0004382>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004382> <http://purl.obolibrary.org/obo/FYPO_0000141>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004416> (<http://purl.obolibrary.org/obo/FYPO_0004416>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004416> <http://purl.obolibrary.org/obo/FYPO_0003195>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004418> (<http://purl.obolibrary.org/obo/FYPO_0004418>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000229>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004418> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002522>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004429> (<http://purl.obolibrary.org/obo/FYPO_0004429>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004429> <http://purl.obolibrary.org/obo/FYPO_0004396>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004440> (<http://purl.obolibrary.org/obo/FYPO_0004440>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004440> <http://purl.obolibrary.org/obo/FYPO_0001199>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004441> (<http://purl.obolibrary.org/obo/FYPO_0004441>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004441> <http://purl.obolibrary.org/obo/FYPO_0001197>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004446> (<http://purl.obolibrary.org/obo/FYPO_0004446>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004446> <http://purl.obolibrary.org/obo/FYPO_0007260>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004448> (<http://purl.obolibrary.org/obo/FYPO_0004448>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004448> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0005208>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004453> (<http://purl.obolibrary.org/obo/FYPO_0004453>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004453> <http://purl.obolibrary.org/obo/FYPO_0001514>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004468> (<http://purl.obolibrary.org/obo/FYPO_0004468>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004468> <http://purl.obolibrary.org/obo/FYPO_0001586>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004473> (<http://purl.obolibrary.org/obo/FYPO_0004473>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004473> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001430>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004493> (<http://purl.obolibrary.org/obo/FYPO_0004493>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004493> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004494> (<http://purl.obolibrary.org/obo/FYPO_0004494>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004494> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004495> (<http://purl.obolibrary.org/obo/FYPO_0004495>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004495> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004496> (<http://purl.obolibrary.org/obo/FYPO_0004496>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004496> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000023>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004496> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004297>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004498> (<http://purl.obolibrary.org/obo/FYPO_0004498>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004498> <http://purl.obolibrary.org/obo/FYPO_0004920>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004502> (<http://purl.obolibrary.org/obo/FYPO_0004502>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004502> <http://purl.obolibrary.org/obo/FYPO_0004920>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004510> (<http://purl.obolibrary.org/obo/FYPO_0004510>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004510> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000734>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004511> (<http://purl.obolibrary.org/obo/FYPO_0004511>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004511> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000233>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004511> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003327>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004521> (<http://purl.obolibrary.org/obo/FYPO_0004521>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004521> <http://purl.obolibrary.org/obo/FYPO_0001512>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004523> (<http://purl.obolibrary.org/obo/FYPO_0004523>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004523> <http://purl.obolibrary.org/obo/FYPO_0005103>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004526> (<http://purl.obolibrary.org/obo/FYPO_0004526>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004526> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004527> (<http://purl.obolibrary.org/obo/FYPO_0004527>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004527> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004531> (<http://purl.obolibrary.org/obo/FYPO_0004531>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004531> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004532> (<http://purl.obolibrary.org/obo/FYPO_0004532>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004532> <http://purl.obolibrary.org/obo/FYPO_0001320>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000338>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004532> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000608>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004533> (<http://purl.obolibrary.org/obo/FYPO_0004533>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004533> <http://purl.obolibrary.org/obo/FYPO_0001078>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004535> (<http://purl.obolibrary.org/obo/FYPO_0004535>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000346>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001126>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002151>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004537> (<http://purl.obolibrary.org/obo/FYPO_0004537>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004537> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0000229>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004537> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003250>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004538> (<http://purl.obolibrary.org/obo/FYPO_0004538>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004538> <http://purl.obolibrary.org/obo/FYPO_0004315>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004539> (<http://purl.obolibrary.org/obo/FYPO_0004539>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004539> <http://purl.obolibrary.org/obo/FYPO_0004638>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004539> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004538>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004539> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006103>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004554> (<http://purl.obolibrary.org/obo/FYPO_0004554>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004554> <http://purl.obolibrary.org/obo/FYPO_0004261>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004559> (<http://purl.obolibrary.org/obo/FYPO_0004559>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004559> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004562> (<http://purl.obolibrary.org/obo/FYPO_0004562>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004562> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004562> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004562> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004567> (<http://purl.obolibrary.org/obo/FYPO_0004567>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004567> <http://purl.obolibrary.org/obo/FYPO_0003607>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004577> (<http://purl.obolibrary.org/obo/FYPO_0004577>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004577> <http://purl.obolibrary.org/obo/FYPO_0000882>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004582> (<http://purl.obolibrary.org/obo/FYPO_0004582>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004582> <http://purl.obolibrary.org/obo/FYPO_0000711>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004592> (<http://purl.obolibrary.org/obo/FYPO_0004592>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004592> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004594> (<http://purl.obolibrary.org/obo/FYPO_0004594>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004594> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004598> (<http://purl.obolibrary.org/obo/FYPO_0004598>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004598> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004603> (<http://purl.obolibrary.org/obo/FYPO_0004603>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004603> <http://purl.obolibrary.org/obo/FYPO_0002273>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004608> (<http://purl.obolibrary.org/obo/FYPO_0004608>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004608> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003561>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004609> (<http://purl.obolibrary.org/obo/FYPO_0004609>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004609> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0007259>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004611> (<http://purl.obolibrary.org/obo/FYPO_0004611>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004611> <http://purl.obolibrary.org/obo/FYPO_0003625>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004611> <http://purl.obolibrary.org/obo/FYPO_0006101>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004624> (<http://purl.obolibrary.org/obo/FYPO_0004624>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004624> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0005687>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004626> (<http://purl.obolibrary.org/obo/FYPO_0004626>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004626> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004651> (<http://purl.obolibrary.org/obo/FYPO_0004651>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004651> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003211>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004656> (<http://purl.obolibrary.org/obo/FYPO_0004656>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004656> <http://purl.obolibrary.org/obo/FYPO_0002840>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004657> (<http://purl.obolibrary.org/obo/FYPO_0004657>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004657> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004658> (<http://purl.obolibrary.org/obo/FYPO_0004658>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004658> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004672> (<http://purl.obolibrary.org/obo/FYPO_0004672>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004672> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004672> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004673> (<http://purl.obolibrary.org/obo/FYPO_0004673>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004673> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004673> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004673> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004684> (<http://purl.obolibrary.org/obo/FYPO_0004684>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004684> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004688> (<http://purl.obolibrary.org/obo/FYPO_0004688>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004688> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004691> (<http://purl.obolibrary.org/obo/FYPO_0004691>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004691> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000129>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004691> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004691> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004703> (<http://purl.obolibrary.org/obo/FYPO_0004703>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004703> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004715> (<http://purl.obolibrary.org/obo/FYPO_0004715>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004715> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000123>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004715> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002793>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004716> (<http://purl.obolibrary.org/obo/FYPO_0004716>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004716> <http://purl.obolibrary.org/obo/FYPO_0002957>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004716> <http://purl.obolibrary.org/obo/FYPO_0005576>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004731> (<http://purl.obolibrary.org/obo/FYPO_0004731>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004731> <http://purl.obolibrary.org/obo/FYPO_0001321>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004735> (<http://purl.obolibrary.org/obo/FYPO_0004735>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004735> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004736> (<http://purl.obolibrary.org/obo/FYPO_0004736>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004736> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0004738>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004748> (<http://purl.obolibrary.org/obo/FYPO_0004748>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004748> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004750> (<http://purl.obolibrary.org/obo/FYPO_0004750>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004750> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004750> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004750> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004753> (<http://purl.obolibrary.org/obo/FYPO_0004753>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004753> <http://purl.obolibrary.org/obo/FYPO_0001424>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004754> (<http://purl.obolibrary.org/obo/FYPO_0004754>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004754> <http://purl.obolibrary.org/obo/FYPO_0003186>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004755> (<http://purl.obolibrary.org/obo/FYPO_0004755>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004755> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004756> (<http://purl.obolibrary.org/obo/FYPO_0004756>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004756> <http://purl.obolibrary.org/obo/FYPO_0000628>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004761> (<http://purl.obolibrary.org/obo/FYPO_0004761>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004761> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004762> (<http://purl.obolibrary.org/obo/FYPO_0004762>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004762> <http://purl.obolibrary.org/obo/FYPO_0006529>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004767> (<http://purl.obolibrary.org/obo/FYPO_0004767>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004767> <http://purl.obolibrary.org/obo/FYPO_0003986>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004768> (<http://purl.obolibrary.org/obo/FYPO_0004768>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004768> <http://purl.obolibrary.org/obo/FYPO_0005263>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004769> (<http://purl.obolibrary.org/obo/FYPO_0004769>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004769> <http://purl.obolibrary.org/obo/FYPO_0006953>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004770> (<http://purl.obolibrary.org/obo/FYPO_0004770>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004770> <http://purl.obolibrary.org/obo/FYPO_0006955>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004771> (<http://purl.obolibrary.org/obo/FYPO_0004771>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004771> <http://purl.obolibrary.org/obo/FYPO_0003986>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004772> (<http://purl.obolibrary.org/obo/FYPO_0004772>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004772> <http://purl.obolibrary.org/obo/FYPO_0001567>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004773> (<http://purl.obolibrary.org/obo/FYPO_0004773>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004773> <http://purl.obolibrary.org/obo/FYPO_0003986>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004774> (<http://purl.obolibrary.org/obo/FYPO_0004774>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004774> <http://purl.obolibrary.org/obo/FYPO_0005237>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004775> (<http://purl.obolibrary.org/obo/FYPO_0004775>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004775> <http://purl.obolibrary.org/obo/FYPO_0001728>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004776> (<http://purl.obolibrary.org/obo/FYPO_0004776>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004776> <http://purl.obolibrary.org/obo/FYPO_0001565>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004780> (<http://purl.obolibrary.org/obo/FYPO_0004780>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004780> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004787> (<http://purl.obolibrary.org/obo/FYPO_0004787>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004787> <http://purl.obolibrary.org/obo/FYPO_0001092>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004790> (<http://purl.obolibrary.org/obo/FYPO_0004790>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004790> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001515>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004802> (<http://purl.obolibrary.org/obo/FYPO_0004802>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004802> <http://purl.obolibrary.org/obo/FYPO_0001370>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004811> (<http://purl.obolibrary.org/obo/FYPO_0004811>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004811> <http://purl.obolibrary.org/obo/FYPO_0004064>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004816> (<http://purl.obolibrary.org/obo/FYPO_0004816>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004816> <http://purl.obolibrary.org/obo/FYPO_0005857>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004830> (<http://purl.obolibrary.org/obo/FYPO_0004830>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004830> <http://purl.obolibrary.org/obo/FYPO_0000502>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004830> <http://purl.obolibrary.org/obo/FYPO_0001334>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004831> (<http://purl.obolibrary.org/obo/FYPO_0004831>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004831> <http://purl.obolibrary.org/obo/FYPO_0003841>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004839> (<http://purl.obolibrary.org/obo/FYPO_0004839>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004839> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004842>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004851> (<http://purl.obolibrary.org/obo/FYPO_0004851>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004851> <http://purl.obolibrary.org/obo/FYPO_0000294>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004859> (<http://purl.obolibrary.org/obo/FYPO_0004859>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004859> <http://purl.obolibrary.org/obo/FYPO_0002627>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004859> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000174>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004860> (<http://purl.obolibrary.org/obo/FYPO_0004860>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004860> <http://purl.obolibrary.org/obo/FYPO_0001194>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004861> (<http://purl.obolibrary.org/obo/FYPO_0004861>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004861> <http://purl.obolibrary.org/obo/FYPO_0001079>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004863> (<http://purl.obolibrary.org/obo/FYPO_0004863>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004863> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000055>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004863> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004862>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004864> (<http://purl.obolibrary.org/obo/FYPO_0004864>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004864> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004864> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004864> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004511>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004865> (<http://purl.obolibrary.org/obo/FYPO_0004865>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004865> <http://purl.obolibrary.org/obo/FYPO_0004612>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004867> (<http://purl.obolibrary.org/obo/FYPO_0004867>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004867> <http://purl.obolibrary.org/obo/FYPO_0002598>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004874> (<http://purl.obolibrary.org/obo/FYPO_0004874>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004874> <http://purl.obolibrary.org/obo/FYPO_0000860>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004891> (<http://purl.obolibrary.org/obo/FYPO_0004891>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004891> <http://purl.obolibrary.org/obo/FYPO_0000548>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004902> (<http://purl.obolibrary.org/obo/FYPO_0004902>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004902> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004902> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004902> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004902> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004904> (<http://purl.obolibrary.org/obo/FYPO_0004904>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004904> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004912> (<http://purl.obolibrary.org/obo/FYPO_0004912>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004912> <http://purl.obolibrary.org/obo/FYPO_0002722>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004922> (<http://purl.obolibrary.org/obo/FYPO_0004922>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004922> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004922> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004922> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004922> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004928> (<http://purl.obolibrary.org/obo/FYPO_0004928>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004928> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004930> (<http://purl.obolibrary.org/obo/FYPO_0004930>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004930> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001219>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004947> (<http://purl.obolibrary.org/obo/FYPO_0004947>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004947> <http://purl.obolibrary.org/obo/FYPO_0005590>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004953> (<http://purl.obolibrary.org/obo/FYPO_0004953>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004953> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001914>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004958> (<http://purl.obolibrary.org/obo/FYPO_0004958>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004958> <http://purl.obolibrary.org/obo/FYPO_0001326>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004960> (<http://purl.obolibrary.org/obo/FYPO_0004960>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004960> <http://purl.obolibrary.org/obo/FYPO_0001317>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004961> (<http://purl.obolibrary.org/obo/FYPO_0004961>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004961> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004965> (<http://purl.obolibrary.org/obo/FYPO_0004965>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004965> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000020>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004965> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004965> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004970> (<http://purl.obolibrary.org/obo/FYPO_0004970>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004970> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004970> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004979> (<http://purl.obolibrary.org/obo/FYPO_0004979>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004979> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004979> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001225>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004988> (<http://purl.obolibrary.org/obo/FYPO_0004988>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004988> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0004990> (<http://purl.obolibrary.org/obo/FYPO_0004990>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0004990> <http://purl.obolibrary.org/obo/FYPO_0000052>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005004> (<http://purl.obolibrary.org/obo/FYPO_0005004>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005004> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005019> (<http://purl.obolibrary.org/obo/FYPO_0005019>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005019> <http://purl.obolibrary.org/obo/FYPO_0000673>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005023> (<http://purl.obolibrary.org/obo/FYPO_0005023>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001490>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002069>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005023> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000229>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005024> (<http://purl.obolibrary.org/obo/FYPO_0005024>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005024> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/FYPO_0000141>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005027> (<http://purl.obolibrary.org/obo/FYPO_0005027>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005027> <http://purl.obolibrary.org/obo/FYPO_0001252>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005027> <http://purl.obolibrary.org/obo/FYPO_0002452>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005043> (<http://purl.obolibrary.org/obo/FYPO_0005043>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005043> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005045> (<http://purl.obolibrary.org/obo/FYPO_0005045>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005045> <http://purl.obolibrary.org/obo/FYPO_0000141>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005062> (<http://purl.obolibrary.org/obo/FYPO_0005062>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005062> <http://purl.obolibrary.org/obo/FYPO_0000869>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005062> <http://purl.obolibrary.org/obo/FYPO_0007375>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005063> (<http://purl.obolibrary.org/obo/FYPO_0005063>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005063> <http://purl.obolibrary.org/obo/FYPO_0000869>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005064> (<http://purl.obolibrary.org/obo/FYPO_0005064>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005064> <http://purl.obolibrary.org/obo/FYPO_0000871>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005064> <http://purl.obolibrary.org/obo/FYPO_0007375>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005065> (<http://purl.obolibrary.org/obo/FYPO_0005065>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005065> <http://purl.obolibrary.org/obo/FYPO_0000871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005066> (<http://purl.obolibrary.org/obo/FYPO_0005066>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005066> <http://purl.obolibrary.org/obo/FYPO_0000871>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005066> <http://purl.obolibrary.org/obo/FYPO_0007374>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005077> (<http://purl.obolibrary.org/obo/FYPO_0005077>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005077> <http://purl.obolibrary.org/obo/FYPO_0006633>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005096> (<http://purl.obolibrary.org/obo/FYPO_0005096>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005096> <http://purl.obolibrary.org/obo/FYPO_0001837>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005103> (<http://purl.obolibrary.org/obo/FYPO_0005103>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005103> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005103> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005118> (<http://purl.obolibrary.org/obo/FYPO_0005118>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005118> <http://purl.obolibrary.org/obo/FYPO_0006550>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005142> (<http://purl.obolibrary.org/obo/FYPO_0005142>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005142> <http://purl.obolibrary.org/obo/FYPO_0001645>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005143> (<http://purl.obolibrary.org/obo/FYPO_0005143>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005143> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005144> (<http://purl.obolibrary.org/obo/FYPO_0005144>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005144> <http://purl.obolibrary.org/obo/FYPO_0001645>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005145> (<http://purl.obolibrary.org/obo/FYPO_0005145>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005145> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005149> (<http://purl.obolibrary.org/obo/FYPO_0005149>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005149> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005149> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005149> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002342>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005155> (<http://purl.obolibrary.org/obo/FYPO_0005155>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005155> <http://purl.obolibrary.org/obo/FYPO_0002327>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005158> (<http://purl.obolibrary.org/obo/FYPO_0005158>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005158> <http://purl.obolibrary.org/obo/FYPO_0002265>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005162> (<http://purl.obolibrary.org/obo/FYPO_0005162>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005162> <http://purl.obolibrary.org/obo/FYPO_0003198>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005167> (<http://purl.obolibrary.org/obo/FYPO_0005167>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005167> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005169> (<http://purl.obolibrary.org/obo/FYPO_0005169>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005169> <http://purl.obolibrary.org/obo/FYPO_0000871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005182> (<http://purl.obolibrary.org/obo/FYPO_0005182>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005182> <http://purl.obolibrary.org/obo/FYPO_0000846>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005188> (<http://purl.obolibrary.org/obo/FYPO_0005188>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005188> <http://purl.obolibrary.org/obo/FYPO_0000711>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005188> <http://purl.obolibrary.org/obo/FYPO_0001339>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005194> (<http://purl.obolibrary.org/obo/FYPO_0005194>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005194> <http://purl.obolibrary.org/obo/FYPO_0000846>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005196> (<http://purl.obolibrary.org/obo/FYPO_0005196>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005196> <http://purl.obolibrary.org/obo/FYPO_0002635>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005201> (<http://purl.obolibrary.org/obo/FYPO_0005201>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005201> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005202> (<http://purl.obolibrary.org/obo/FYPO_0005202>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005202> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005208> (<http://purl.obolibrary.org/obo/FYPO_0005208>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005208> <http://purl.obolibrary.org/obo/FYPO_0006393>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005210> (<http://purl.obolibrary.org/obo/FYPO_0005210>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005210> <http://purl.obolibrary.org/obo/FYPO_0001269>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005215> (<http://purl.obolibrary.org/obo/FYPO_0005215>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005215> <http://purl.obolibrary.org/obo/FYPO_0002902>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005234> (<http://purl.obolibrary.org/obo/FYPO_0005234>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005234> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005268> (<http://purl.obolibrary.org/obo/FYPO_0005268>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005268> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005271> (<http://purl.obolibrary.org/obo/FYPO_0005271>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005271> <http://purl.obolibrary.org/obo/FYPO_0002737>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005271> <http://purl.obolibrary.org/obo/FYPO_0006329>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005271> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/FYPO_0000141>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005277> (<http://purl.obolibrary.org/obo/FYPO_0005277>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005277> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003341>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005277> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004295>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005289> (<http://purl.obolibrary.org/obo/FYPO_0005289>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005289> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002026>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005290> (<http://purl.obolibrary.org/obo/FYPO_0005290>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005290> <http://purl.obolibrary.org/obo/FYPO_0005544>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005295> (<http://purl.obolibrary.org/obo/FYPO_0005295>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005295> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001890>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005304> (<http://purl.obolibrary.org/obo/FYPO_0005304>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005304> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005314> (<http://purl.obolibrary.org/obo/FYPO_0005314>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005314> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005316> (<http://purl.obolibrary.org/obo/FYPO_0005316>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005316> <http://purl.obolibrary.org/obo/FYPO_0002365>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005321> (<http://purl.obolibrary.org/obo/FYPO_0005321>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000620>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005321> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005338> (<http://purl.obolibrary.org/obo/FYPO_0005338>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005338> <http://purl.obolibrary.org/obo/FYPO_0001514>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005339> (<http://purl.obolibrary.org/obo/FYPO_0005339>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005339> <http://purl.obolibrary.org/obo/FYPO_0001130>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005343> (<http://purl.obolibrary.org/obo/FYPO_0005343>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005343> <http://purl.obolibrary.org/obo/FYPO_0003268>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005355> (<http://purl.obolibrary.org/obo/FYPO_0005355>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005355> <http://purl.obolibrary.org/obo/FYPO_0001346>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005355> <http://purl.obolibrary.org/obo/FYPO_0001363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005359> (<http://purl.obolibrary.org/obo/FYPO_0005359>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005359> <http://purl.obolibrary.org/obo/FYPO_0000290>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005359> <http://purl.obolibrary.org/obo/FYPO_0000859>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005359> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005362> (<http://purl.obolibrary.org/obo/FYPO_0005362>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005362> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/FYPO_0000141>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005367> (<http://purl.obolibrary.org/obo/FYPO_0005367>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005367> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005378> (<http://purl.obolibrary.org/obo/FYPO_0005378>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005378> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005379> (<http://purl.obolibrary.org/obo/FYPO_0005379>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005379> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0005378>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005382> (<http://purl.obolibrary.org/obo/FYPO_0005382>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005382> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005385> (<http://purl.obolibrary.org/obo/FYPO_0005385>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005385> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0001946>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005394> (<http://purl.obolibrary.org/obo/FYPO_0005394>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005394> <http://purl.obolibrary.org/obo/FYPO_0001356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005419> (<http://purl.obolibrary.org/obo/FYPO_0005419>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005419> <http://purl.obolibrary.org/obo/FYPO_0000359>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005422> (<http://purl.obolibrary.org/obo/FYPO_0005422>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000837>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005422> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001919>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005424> (<http://purl.obolibrary.org/obo/FYPO_0005424>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005424> <http://purl.obolibrary.org/obo/FYPO_0003286>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005425> (<http://purl.obolibrary.org/obo/FYPO_0005425>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000016>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005425> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004863>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005426> (<http://purl.obolibrary.org/obo/FYPO_0005426>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004863>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005426> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005789>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005427> (<http://purl.obolibrary.org/obo/FYPO_0005427>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004863>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005427> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005790>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005429> (<http://purl.obolibrary.org/obo/FYPO_0005429>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005429> <http://purl.obolibrary.org/obo/FYPO_0004031>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005438> (<http://purl.obolibrary.org/obo/FYPO_0005438>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005438> <http://purl.obolibrary.org/obo/FYPO_0001092>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005440> (<http://purl.obolibrary.org/obo/FYPO_0005440>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000344>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005440> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005443> (<http://purl.obolibrary.org/obo/FYPO_0005443>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005443> <http://purl.obolibrary.org/obo/FYPO_0000545>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005444> (<http://purl.obolibrary.org/obo/FYPO_0005444>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005444> <http://purl.obolibrary.org/obo/FYPO_0001356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005463> (<http://purl.obolibrary.org/obo/FYPO_0005463>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005463> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0006103>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005467> (<http://purl.obolibrary.org/obo/FYPO_0005467>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005467> <http://purl.obolibrary.org/obo/FYPO_0002699>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005468> (<http://purl.obolibrary.org/obo/FYPO_0005468>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005468> <http://purl.obolibrary.org/obo/FYPO_0002852>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005475> (<http://purl.obolibrary.org/obo/FYPO_0005475>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005475> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005475> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005475> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003503>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005493> (<http://purl.obolibrary.org/obo/FYPO_0005493>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005493> <http://purl.obolibrary.org/obo/FYPO_0001071>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005497> (<http://purl.obolibrary.org/obo/FYPO_0005497>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005497> <http://purl.obolibrary.org/obo/FYPO_0005496>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005501> (<http://purl.obolibrary.org/obo/FYPO_0005501>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005501> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005507> (<http://purl.obolibrary.org/obo/FYPO_0005507>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005507> <http://purl.obolibrary.org/obo/FYPO_0006468>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005509> (<http://purl.obolibrary.org/obo/FYPO_0005509>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005509> <http://purl.obolibrary.org/obo/FYPO_0000051>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005513> (<http://purl.obolibrary.org/obo/FYPO_0005513>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005513> <http://purl.obolibrary.org/obo/FYPO_0005598>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005515> (<http://purl.obolibrary.org/obo/FYPO_0005515>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005515> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005514>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005518> (<http://purl.obolibrary.org/obo/FYPO_0005518>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005518> <http://purl.obolibrary.org/obo/FYPO_0005310>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005534> (<http://purl.obolibrary.org/obo/FYPO_0005534>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005534> <http://purl.obolibrary.org/obo/FYPO_0005011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005535> (<http://purl.obolibrary.org/obo/FYPO_0005535>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005535> <http://purl.obolibrary.org/obo/FYPO_0002365>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005536> (<http://purl.obolibrary.org/obo/FYPO_0005536>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005536> <http://purl.obolibrary.org/obo/FYPO_0001319>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005536> <http://purl.obolibrary.org/obo/FYPO_0001337>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005555> (<http://purl.obolibrary.org/obo/FYPO_0005555>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005555> <http://purl.obolibrary.org/obo/FYPO_0000682>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005556> (<http://purl.obolibrary.org/obo/FYPO_0005556>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005556> <http://purl.obolibrary.org/obo/FYPO_0000682>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005559> (<http://purl.obolibrary.org/obo/FYPO_0005559>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005559> <http://purl.obolibrary.org/obo/FYPO_0001418>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005560> (<http://purl.obolibrary.org/obo/FYPO_0005560>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005560> <http://purl.obolibrary.org/obo/FYPO_0001418>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005561> (<http://purl.obolibrary.org/obo/FYPO_0005561>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005561> <http://purl.obolibrary.org/obo/FYPO_0001418>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005563> (<http://purl.obolibrary.org/obo/FYPO_0005563>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005563> <http://purl.obolibrary.org/obo/FYPO_0005558>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005563> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005559>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005563> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005561>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005564> (<http://purl.obolibrary.org/obo/FYPO_0005564>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005564> <http://purl.obolibrary.org/obo/FYPO_0005558>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005564> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005560>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005564> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005562>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005566> (<http://purl.obolibrary.org/obo/FYPO_0005566>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005566> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0005568>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005576> (<http://purl.obolibrary.org/obo/FYPO_0005576>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005576> <http://purl.obolibrary.org/obo/FYPO_0004094>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005594> (<http://purl.obolibrary.org/obo/FYPO_0005594>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005594> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005601> (<http://purl.obolibrary.org/obo/FYPO_0005601>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005601> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000641>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005603> (<http://purl.obolibrary.org/obo/FYPO_0005603>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005603> <http://purl.obolibrary.org/obo/FYPO_0002341>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005608> (<http://purl.obolibrary.org/obo/FYPO_0005608>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005608> <http://purl.obolibrary.org/obo/FYPO_0002768>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005611> (<http://purl.obolibrary.org/obo/FYPO_0005611>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005611> <http://purl.obolibrary.org/obo/FYPO_0000869>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005662> (<http://purl.obolibrary.org/obo/FYPO_0005662>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005662> <http://purl.obolibrary.org/obo/FYPO_0000780>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005664> (<http://purl.obolibrary.org/obo/FYPO_0005664>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005664> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005664> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000124>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005664> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000998>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005665> (<http://purl.obolibrary.org/obo/FYPO_0005665>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005665> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0004803>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005667> (<http://purl.obolibrary.org/obo/FYPO_0005667>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005667> <http://purl.obolibrary.org/obo/FYPO_0001129>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005672> (<http://purl.obolibrary.org/obo/FYPO_0005672>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005672> <http://purl.obolibrary.org/obo/FYPO_0001514>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005673> (<http://purl.obolibrary.org/obo/FYPO_0005673>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005673> <http://purl.obolibrary.org/obo/FYPO_0003143>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005674> (<http://purl.obolibrary.org/obo/FYPO_0005674>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005674> <http://purl.obolibrary.org/obo/FYPO_0005333>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005676> (<http://purl.obolibrary.org/obo/FYPO_0005676>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005676> <http://purl.obolibrary.org/obo/FYPO_0005377>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005679> (<http://purl.obolibrary.org/obo/FYPO_0005679>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005679> <http://purl.obolibrary.org/obo/FYPO_0005443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005683> (<http://purl.obolibrary.org/obo/FYPO_0005683>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005683> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005684> (<http://purl.obolibrary.org/obo/FYPO_0005684>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005684> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005689> (<http://purl.obolibrary.org/obo/FYPO_0005689>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005689> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002888>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005691> (<http://purl.obolibrary.org/obo/FYPO_0005691>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005691> <http://purl.obolibrary.org/obo/FYPO_0005462>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005692> (<http://purl.obolibrary.org/obo/FYPO_0005692>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005692> <http://purl.obolibrary.org/obo/FYPO_0001350>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005698> (<http://purl.obolibrary.org/obo/FYPO_0005698>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005698> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0004619>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005709> (<http://purl.obolibrary.org/obo/FYPO_0005709>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005709> <http://purl.obolibrary.org/obo/FYPO_0002967>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005711> (<http://purl.obolibrary.org/obo/FYPO_0005711>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005711> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005720> (<http://purl.obolibrary.org/obo/FYPO_0005720>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005720> <http://purl.obolibrary.org/obo/FYPO_0001337>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005721> (<http://purl.obolibrary.org/obo/FYPO_0005721>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005721> <http://purl.obolibrary.org/obo/FYPO_0003607>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005735> (<http://purl.obolibrary.org/obo/FYPO_0005735>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005735> <http://purl.obolibrary.org/obo/FYPO_0003003>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005755> (<http://purl.obolibrary.org/obo/FYPO_0005755>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005755> <http://purl.obolibrary.org/obo/FYPO_0001194>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005773> (<http://purl.obolibrary.org/obo/FYPO_0005773>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005773> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005773> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005773> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005775> (<http://purl.obolibrary.org/obo/FYPO_0005775>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005775> <http://purl.obolibrary.org/obo/FYPO_0000266>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005778> (<http://purl.obolibrary.org/obo/FYPO_0005778>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005778> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000641>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005779> (<http://purl.obolibrary.org/obo/FYPO_0005779>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005779> <http://purl.obolibrary.org/obo/FYPO_0002901>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005782> (<http://purl.obolibrary.org/obo/FYPO_0005782>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005782> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005784> (<http://purl.obolibrary.org/obo/FYPO_0005784>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005784> <http://purl.obolibrary.org/obo/FYPO_0000704>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005784> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005784> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005785>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005791> (<http://purl.obolibrary.org/obo/FYPO_0005791>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005791> <http://purl.obolibrary.org/obo/FYPO_0000628>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005791> <http://purl.obolibrary.org/obo/FYPO_0000679>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005795> (<http://purl.obolibrary.org/obo/FYPO_0005795>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005795> <http://purl.obolibrary.org/obo/FYPO_0003064>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005796> (<http://purl.obolibrary.org/obo/FYPO_0005796>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005796> <http://purl.obolibrary.org/obo/FYPO_0005558>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005796> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005795>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005796> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0005797>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005797> (<http://purl.obolibrary.org/obo/FYPO_0005797>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005797> <http://purl.obolibrary.org/obo/FYPO_0001418>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005811> (<http://purl.obolibrary.org/obo/FYPO_0005811>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005811> <http://purl.obolibrary.org/obo/FYPO_0001351>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005811> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005817> (<http://purl.obolibrary.org/obo/FYPO_0005817>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005817> <http://purl.obolibrary.org/obo/FYPO_0005441>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005817> <http://purl.obolibrary.org/obo/FYPO_0005814>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005823> (<http://purl.obolibrary.org/obo/FYPO_0005823>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005823> <http://purl.obolibrary.org/obo/FYPO_0001505>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005824> (<http://purl.obolibrary.org/obo/FYPO_0005824>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005824> <http://purl.obolibrary.org/obo/FYPO_0000364>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005833> (<http://purl.obolibrary.org/obo/FYPO_0005833>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005833> <http://purl.obolibrary.org/obo/FYPO_0005831>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005834> (<http://purl.obolibrary.org/obo/FYPO_0005834>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005834> <http://purl.obolibrary.org/obo/FYPO_0005494>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005834> <http://purl.obolibrary.org/obo/FYPO_0005832>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005836> (<http://purl.obolibrary.org/obo/FYPO_0005836>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005836> <http://purl.obolibrary.org/obo/FYPO_0005831>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005837> (<http://purl.obolibrary.org/obo/FYPO_0005837>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005837> <http://purl.obolibrary.org/obo/FYPO_0005832>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005844> (<http://purl.obolibrary.org/obo/FYPO_0005844>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005844> <http://purl.obolibrary.org/obo/FYPO_0007373>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005845> (<http://purl.obolibrary.org/obo/FYPO_0005845>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005845> <http://purl.obolibrary.org/obo/FYPO_0000882>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005845> <http://purl.obolibrary.org/obo/FYPO_0007373>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005861> (<http://purl.obolibrary.org/obo/FYPO_0005861>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005861> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005862> (<http://purl.obolibrary.org/obo/FYPO_0005862>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005862> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005869> (<http://purl.obolibrary.org/obo/FYPO_0005869>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005869> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005869> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005869> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005873> (<http://purl.obolibrary.org/obo/FYPO_0005873>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005873> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003211>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005888> (<http://purl.obolibrary.org/obo/FYPO_0005888>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005888> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002843>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005894> (<http://purl.obolibrary.org/obo/FYPO_0005894>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005894> <http://purl.obolibrary.org/obo/FYPO_0001509>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005895> (<http://purl.obolibrary.org/obo/FYPO_0005895>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005895> <http://purl.obolibrary.org/obo/FYPO_0005896>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005895> <http://purl.obolibrary.org/obo/FYPO_0006599>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005896> (<http://purl.obolibrary.org/obo/FYPO_0005896>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005896> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005897> (<http://purl.obolibrary.org/obo/FYPO_0005897>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005897> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005898> (<http://purl.obolibrary.org/obo/FYPO_0005898>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005898> <http://purl.obolibrary.org/obo/FYPO_0005897>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005921> (<http://purl.obolibrary.org/obo/FYPO_0005921>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005921> <http://purl.obolibrary.org/obo/FYPO_0002365>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005922> (<http://purl.obolibrary.org/obo/FYPO_0005922>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005922> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005973> (<http://purl.obolibrary.org/obo/FYPO_0005973>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005973> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005974> (<http://purl.obolibrary.org/obo/FYPO_0005974>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005974> <http://purl.obolibrary.org/obo/FYPO_0000833>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005988> (<http://purl.obolibrary.org/obo/FYPO_0005988>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005988> <http://purl.obolibrary.org/obo/FYPO_0006393>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0005994> (<http://purl.obolibrary.org/obo/FYPO_0005994>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005994> <http://purl.obolibrary.org/obo/FYPO_0000294>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005994> <http://purl.obolibrary.org/obo/FYPO_0001333>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0005994> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006006> (<http://purl.obolibrary.org/obo/FYPO_0006006>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000622>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002888>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006012> (<http://purl.obolibrary.org/obo/FYPO_0006012>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006012> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006012> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000569>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006012> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000998>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006022> (<http://purl.obolibrary.org/obo/FYPO_0006022>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006022> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0003561>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006023> (<http://purl.obolibrary.org/obo/FYPO_0006023>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006023> <http://purl.obolibrary.org/obo/FYPO_0000223>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006028> (<http://purl.obolibrary.org/obo/FYPO_0006028>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006028> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006032> (<http://purl.obolibrary.org/obo/FYPO_0006032>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006032> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006034> (<http://purl.obolibrary.org/obo/FYPO_0006034>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006034> <http://purl.obolibrary.org/obo/FYPO_0001313>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006044> (<http://purl.obolibrary.org/obo/FYPO_0006044>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006044> <http://purl.obolibrary.org/obo/FYPO_0000733>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006047> (<http://purl.obolibrary.org/obo/FYPO_0006047>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006047> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001778>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006050> (<http://purl.obolibrary.org/obo/FYPO_0006050>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006050> <http://purl.obolibrary.org/obo/FYPO_0004301>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006051> (<http://purl.obolibrary.org/obo/FYPO_0006051>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006051> <http://purl.obolibrary.org/obo/FYPO_0001351>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006051> <http://purl.obolibrary.org/obo/FYPO_0001354>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006054> (<http://purl.obolibrary.org/obo/FYPO_0006054>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006054> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002552>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006059> (<http://purl.obolibrary.org/obo/FYPO_0006059>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006059> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006076> (<http://purl.obolibrary.org/obo/FYPO_0006076>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006076> <http://purl.obolibrary.org/obo/FYPO_0004205>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006077> (<http://purl.obolibrary.org/obo/FYPO_0006077>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006077> <http://purl.obolibrary.org/obo/FYPO_0000871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006082> (<http://purl.obolibrary.org/obo/FYPO_0006082>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006082> <http://purl.obolibrary.org/obo/FYPO_0006003>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006103> (<http://purl.obolibrary.org/obo/FYPO_0006103>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006103> <http://purl.obolibrary.org/obo/FYPO_0003625>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006103> <http://purl.obolibrary.org/obo/FYPO_0006101>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006112> (<http://purl.obolibrary.org/obo/FYPO_0006112>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006112> <http://purl.obolibrary.org/obo/FYPO_0007373>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006117> (<http://purl.obolibrary.org/obo/FYPO_0006117>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006117> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006134> (<http://purl.obolibrary.org/obo/FYPO_0006134>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006134> <http://purl.obolibrary.org/obo/FYPO_0001330>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006142> (<http://purl.obolibrary.org/obo/FYPO_0006142>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006142> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006148> (<http://purl.obolibrary.org/obo/FYPO_0006148>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006148> <http://purl.obolibrary.org/obo/FYPO_0005118>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006165> (<http://purl.obolibrary.org/obo/FYPO_0006165>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006165> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006166> (<http://purl.obolibrary.org/obo/FYPO_0006166>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006166> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006167> (<http://purl.obolibrary.org/obo/FYPO_0006167>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006167> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006188> (<http://purl.obolibrary.org/obo/FYPO_0006188>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006188> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006191> (<http://purl.obolibrary.org/obo/FYPO_0006191>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006191> <http://purl.obolibrary.org/obo/FYPO_0005672>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006191> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006192> (<http://purl.obolibrary.org/obo/FYPO_0006192>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000021>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000926>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006192> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006193> (<http://purl.obolibrary.org/obo/FYPO_0006193>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006193> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000573>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006196> (<http://purl.obolibrary.org/obo/FYPO_0006196>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006196> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0003328>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006196> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006103>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006197> (<http://purl.obolibrary.org/obo/FYPO_0006197>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006197> <http://purl.obolibrary.org/obo/FYPO_0002199>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006198> (<http://purl.obolibrary.org/obo/FYPO_0006198>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006198> <http://purl.obolibrary.org/obo/FYPO_0002199>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006199> (<http://purl.obolibrary.org/obo/FYPO_0006199>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006199> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006201> (<http://purl.obolibrary.org/obo/FYPO_0006201>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006201> <http://purl.obolibrary.org/obo/FYPO_0001362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006209> (<http://purl.obolibrary.org/obo/FYPO_0006209>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006209> <http://purl.obolibrary.org/obo/FYPO_0006208>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006221> (<http://purl.obolibrary.org/obo/FYPO_0006221>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006221> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006222> (<http://purl.obolibrary.org/obo/FYPO_0006222>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006222> <http://purl.obolibrary.org/obo/FYPO_0003278>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006223> (<http://purl.obolibrary.org/obo/FYPO_0006223>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006223> <http://purl.obolibrary.org/obo/FYPO_0005973>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006229> (<http://purl.obolibrary.org/obo/FYPO_0006229>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006229> <http://purl.obolibrary.org/obo/FYPO_0000548>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006230> (<http://purl.obolibrary.org/obo/FYPO_0006230>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006230> <http://purl.obolibrary.org/obo/FYPO_0003125>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006231> (<http://purl.obolibrary.org/obo/FYPO_0006231>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006231> <http://purl.obolibrary.org/obo/FYPO_0003125>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006240> (<http://purl.obolibrary.org/obo/FYPO_0006240>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006240> <http://purl.obolibrary.org/obo/FYPO_0003923>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006250> (<http://purl.obolibrary.org/obo/FYPO_0006250>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006250> <http://purl.obolibrary.org/obo/FYPO_0001347>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006250> <http://purl.obolibrary.org/obo/FYPO_0001363>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006262> (<http://purl.obolibrary.org/obo/FYPO_0006262>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000024>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001222>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006262> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006270> (<http://purl.obolibrary.org/obo/FYPO_0006270>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006270> <http://purl.obolibrary.org/obo/FYPO_0003195>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006272> (<http://purl.obolibrary.org/obo/FYPO_0006272>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006272> <http://purl.obolibrary.org/obo/FYPO_0003498>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006272> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0005758>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006274> (<http://purl.obolibrary.org/obo/FYPO_0006274>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006274> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0006292>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006279> (<http://purl.obolibrary.org/obo/FYPO_0006279>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006279> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006290> (<http://purl.obolibrary.org/obo/FYPO_0006290>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006290> <http://purl.obolibrary.org/obo/FYPO_0002099>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006294> (<http://purl.obolibrary.org/obo/FYPO_0006294>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006294> <http://purl.obolibrary.org/obo/FYPO_0000140>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006300> (<http://purl.obolibrary.org/obo/FYPO_0006300>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006300> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006313> (<http://purl.obolibrary.org/obo/FYPO_0006313>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006313> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006328> (<http://purl.obolibrary.org/obo/FYPO_0006328>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006328> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006339> (<http://purl.obolibrary.org/obo/FYPO_0006339>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006339> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006339> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006339> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0002069>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006351> (<http://purl.obolibrary.org/obo/FYPO_0006351>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006351> <http://purl.obolibrary.org/obo/FYPO_0001474>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006359> (<http://purl.obolibrary.org/obo/FYPO_0006359>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006359> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006360> (<http://purl.obolibrary.org/obo/FYPO_0006360>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006360> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006364> (<http://purl.obolibrary.org/obo/FYPO_0006364>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006364> <http://purl.obolibrary.org/obo/FYPO_0006022>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006370> (<http://purl.obolibrary.org/obo/FYPO_0006370>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006370> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006379> (<http://purl.obolibrary.org/obo/FYPO_0006379>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006379> <http://purl.obolibrary.org/obo/FYPO_0001375>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006387> (<http://purl.obolibrary.org/obo/FYPO_0006387>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006387> <http://purl.obolibrary.org/obo/FYPO_0001353>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006397> (<http://purl.obolibrary.org/obo/FYPO_0006397>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006397> <http://purl.obolibrary.org/obo/FYPO_0004088>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006426> (<http://purl.obolibrary.org/obo/FYPO_0006426>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006426> <http://purl.obolibrary.org/obo/FYPO_0006915>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006427> (<http://purl.obolibrary.org/obo/FYPO_0006427>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006427> <http://purl.obolibrary.org/obo/FYPO_0000325>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006428> (<http://purl.obolibrary.org/obo/FYPO_0006428>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006428> <http://purl.obolibrary.org/obo/FYPO_0001319>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006428> <http://purl.obolibrary.org/obo/FYPO_0001334>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006428> <http://purl.obolibrary.org/obo/FYPO_0006915>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006430> (<http://purl.obolibrary.org/obo/FYPO_0006430>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006430> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006430> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006460> (<http://purl.obolibrary.org/obo/FYPO_0006460>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006460> <http://purl.obolibrary.org/obo/FYPO_0003565>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006461> (<http://purl.obolibrary.org/obo/FYPO_0006461>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006461> <http://purl.obolibrary.org/obo/FYPO_0003565>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006462> (<http://purl.obolibrary.org/obo/FYPO_0006462>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006462> <http://purl.obolibrary.org/obo/FYPO_0003565>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006467> (<http://purl.obolibrary.org/obo/FYPO_0006467>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006467> <http://purl.obolibrary.org/obo/FYPO_0006465>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006470> (<http://purl.obolibrary.org/obo/FYPO_0006470>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006470> <http://purl.obolibrary.org/obo/FYPO_0006468>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006474> (<http://purl.obolibrary.org/obo/FYPO_0006474>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006474> <http://purl.obolibrary.org/obo/FYPO_0001362>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006474> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006476> (<http://purl.obolibrary.org/obo/FYPO_0006476>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006476> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0006490>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006479> (<http://purl.obolibrary.org/obo/FYPO_0006479>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006479> <http://purl.obolibrary.org/obo/FYPO_0000145>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006480> (<http://purl.obolibrary.org/obo/FYPO_0006480>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006480> <http://purl.obolibrary.org/obo/FYPO_0000145>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006480> <http://purl.obolibrary.org/obo/FYPO_0002333>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006481> (<http://purl.obolibrary.org/obo/FYPO_0006481>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006481> <http://purl.obolibrary.org/obo/FYPO_0000682>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006519> (<http://purl.obolibrary.org/obo/FYPO_0006519>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006519> <http://purl.obolibrary.org/obo/FYPO_0000846>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006521> (<http://purl.obolibrary.org/obo/FYPO_0006521>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006521> <http://purl.obolibrary.org/obo/FYPO_0000641>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006521> <http://purl.obolibrary.org/obo/FYPO_0001353>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006521> <http://purl.obolibrary.org/obo/FYPO_0002737>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006532> (<http://purl.obolibrary.org/obo/FYPO_0006532>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006532> <http://purl.obolibrary.org/obo/FYPO_0003549>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006558> (<http://purl.obolibrary.org/obo/FYPO_0006558>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006558> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0006557>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006583> (<http://purl.obolibrary.org/obo/FYPO_0006583>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006583> <http://purl.obolibrary.org/obo/FYPO_0002339>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006588> (<http://purl.obolibrary.org/obo/FYPO_0006588>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006588> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006590>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006589> (<http://purl.obolibrary.org/obo/FYPO_0006589>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006589> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006386>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006599> (<http://purl.obolibrary.org/obo/FYPO_0006599>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006599> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006600> (<http://purl.obolibrary.org/obo/FYPO_0006600>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006600> <http://purl.obolibrary.org/obo/FYPO_0003002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006600> <http://purl.obolibrary.org/obo/FYPO_0006599>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006612> (<http://purl.obolibrary.org/obo/FYPO_0006612>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006612> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006613> (<http://purl.obolibrary.org/obo/FYPO_0006613>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006613> <http://purl.obolibrary.org/obo/FYPO_0000781>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006614> (<http://purl.obolibrary.org/obo/FYPO_0006614>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006614> <http://purl.obolibrary.org/obo/FYPO_0000780>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006616> (<http://purl.obolibrary.org/obo/FYPO_0006616>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006616> <http://purl.obolibrary.org/obo/FYPO_0001321>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006616> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006615>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006617> (<http://purl.obolibrary.org/obo/FYPO_0006617>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006617> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006615>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006623> (<http://purl.obolibrary.org/obo/FYPO_0006623>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006623> <http://purl.obolibrary.org/obo/FYPO_0006486>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006624> (<http://purl.obolibrary.org/obo/FYPO_0006624>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006624> <http://purl.obolibrary.org/obo/FYPO_0003278>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006624> <http://purl.obolibrary.org/obo/FYPO_0006488>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006626> (<http://purl.obolibrary.org/obo/FYPO_0006626>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006626> <http://purl.obolibrary.org/obo/FYPO_0003278>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006627> (<http://purl.obolibrary.org/obo/FYPO_0006627>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006627> <http://purl.obolibrary.org/obo/FYPO_0001507>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006628> (<http://purl.obolibrary.org/obo/FYPO_0006628>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006628> <http://purl.obolibrary.org/obo/FYPO_0006775>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006629> (<http://purl.obolibrary.org/obo/FYPO_0006629>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006629> <http://purl.obolibrary.org/obo/FYPO_0001507>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006630> (<http://purl.obolibrary.org/obo/FYPO_0006630>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000949>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006630> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004043>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006634> (<http://purl.obolibrary.org/obo/FYPO_0006634>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006634> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006635> (<http://purl.obolibrary.org/obo/FYPO_0006635>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006635> <http://purl.obolibrary.org/obo/FYPO_0001587>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006656> (<http://purl.obolibrary.org/obo/FYPO_0006656>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006656> <http://purl.obolibrary.org/obo/FYPO_0001353>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006669> (<http://purl.obolibrary.org/obo/FYPO_0006669>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006669> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003263>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006671> (<http://purl.obolibrary.org/obo/FYPO_0006671>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006671> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0003263>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006672> (<http://purl.obolibrary.org/obo/FYPO_0006672>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006672> <http://purl.obolibrary.org/obo/FYPO_0000031>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006681> (<http://purl.obolibrary.org/obo/FYPO_0006681>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006681> <http://purl.obolibrary.org/obo/FYPO_0000892>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006682> (<http://purl.obolibrary.org/obo/FYPO_0006682>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006682> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006690> (<http://purl.obolibrary.org/obo/FYPO_0006690>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006690> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000141>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006690> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006693> (<http://purl.obolibrary.org/obo/FYPO_0006693>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006693> <http://purl.obolibrary.org/obo/FYPO_0003871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006694> (<http://purl.obolibrary.org/obo/FYPO_0006694>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006694> <http://purl.obolibrary.org/obo/FYPO_0003871>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006712> (<http://purl.obolibrary.org/obo/FYPO_0006712>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006712> <http://purl.obolibrary.org/obo/FYPO_0001329>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006718> (<http://purl.obolibrary.org/obo/FYPO_0006718>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006718> <http://purl.obolibrary.org/obo/FYPO_0000548>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006740> (<http://purl.obolibrary.org/obo/FYPO_0006740>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006740> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006743> (<http://purl.obolibrary.org/obo/FYPO_0006743>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006743> <http://purl.obolibrary.org/obo/FYPO_0001514>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006751> (<http://purl.obolibrary.org/obo/FYPO_0006751>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006751> <http://purl.obolibrary.org/obo/FYPO_0000869>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006752> (<http://purl.obolibrary.org/obo/FYPO_0006752>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006752> <http://purl.obolibrary.org/obo/FYPO_0002365>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006753> (<http://purl.obolibrary.org/obo/FYPO_0006753>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006753> <http://purl.obolibrary.org/obo/FYPO_0005028>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006764> (<http://purl.obolibrary.org/obo/FYPO_0006764>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006764> <http://purl.obolibrary.org/obo/FYPO_0006915>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006782> (<http://purl.obolibrary.org/obo/FYPO_0006782>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006782> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006784> (<http://purl.obolibrary.org/obo/FYPO_0006784>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006784> <http://purl.obolibrary.org/obo/FYPO_0000368>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006794> (<http://purl.obolibrary.org/obo/FYPO_0006794>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006794> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006795> (<http://purl.obolibrary.org/obo/FYPO_0006795>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006795> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000784>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006796> (<http://purl.obolibrary.org/obo/FYPO_0006796>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006796> <http://purl.obolibrary.org/obo/FYPO_0005501>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006796> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006799> (<http://purl.obolibrary.org/obo/FYPO_0006799>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006799> <http://purl.obolibrary.org/obo/FYPO_0000705>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006801> (<http://purl.obolibrary.org/obo/FYPO_0006801>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006801> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0001791>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006808> (<http://purl.obolibrary.org/obo/FYPO_0006808>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006808> <http://purl.obolibrary.org/obo/FYPO_0001333>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006808> <http://purl.obolibrary.org/obo/FYPO_0006551>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006812> (<http://purl.obolibrary.org/obo/FYPO_0006812>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006812> <http://purl.obolibrary.org/obo/FYPO_0001322>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006814> (<http://purl.obolibrary.org/obo/FYPO_0006814>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006814> <http://purl.obolibrary.org/obo/FYPO_0000892>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006815> (<http://purl.obolibrary.org/obo/FYPO_0006815>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006815> <http://purl.obolibrary.org/obo/FYPO_0005310>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006818> (<http://purl.obolibrary.org/obo/FYPO_0006818>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006818> <http://purl.obolibrary.org/obo/FYPO_0002909>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006822> (<http://purl.obolibrary.org/obo/FYPO_0006822>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006822> <http://purl.obolibrary.org/obo/FYPO_0001320>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006822> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006822> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001046>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006822> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006822> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006819>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006823> (<http://purl.obolibrary.org/obo/FYPO_0006823>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006823> <http://purl.obolibrary.org/obo/FYPO_0001320>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006823> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006823> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006823> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0006821>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006825> (<http://purl.obolibrary.org/obo/FYPO_0006825>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006825> <http://purl.obolibrary.org/obo/FYPO_0000941>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006827> (<http://purl.obolibrary.org/obo/FYPO_0006827>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006827> <http://purl.obolibrary.org/obo/FYPO_0001534>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006828> (<http://purl.obolibrary.org/obo/FYPO_0006828>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006828> <http://purl.obolibrary.org/obo/FYPO_0001552>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006837> (<http://purl.obolibrary.org/obo/FYPO_0006837>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006837> <http://purl.obolibrary.org/obo/FYPO_0000547>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006839> (<http://purl.obolibrary.org/obo/FYPO_0006839>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006839> <http://purl.obolibrary.org/obo/FYPO_0000627>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006843> (<http://purl.obolibrary.org/obo/FYPO_0006843>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006843> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006853> (<http://purl.obolibrary.org/obo/FYPO_0006853>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006853> <http://purl.obolibrary.org/obo/FYPO_0001677>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006861> (<http://purl.obolibrary.org/obo/FYPO_0006861>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006861> <http://purl.obolibrary.org/obo/FYPO_0001321>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006861> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0000360>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006862> (<http://purl.obolibrary.org/obo/FYPO_0006862>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006862> <http://purl.obolibrary.org/obo/FYPO_0000783>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006866> (<http://purl.obolibrary.org/obo/FYPO_0006866>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006866> <http://purl.obolibrary.org/obo/FYPO_0000443>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006872> (<http://purl.obolibrary.org/obo/FYPO_0006872>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006872> <http://purl.obolibrary.org/obo/FYPO_0002596>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006883> (<http://purl.obolibrary.org/obo/FYPO_0006883>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006883> <http://purl.obolibrary.org/obo/FYPO_0004572>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006884> (<http://purl.obolibrary.org/obo/FYPO_0006884>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006884> <http://purl.obolibrary.org/obo/FYPO_0003607>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006885> (<http://purl.obolibrary.org/obo/FYPO_0006885>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006885> <http://purl.obolibrary.org/obo/FYPO_0000338>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006886> (<http://purl.obolibrary.org/obo/FYPO_0006886>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006886> <http://purl.obolibrary.org/obo/FYPO_0000338>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006895> (<http://purl.obolibrary.org/obo/FYPO_0006895>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006895> <http://purl.obolibrary.org/obo/FYPO_0003549>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006896> (<http://purl.obolibrary.org/obo/FYPO_0006896>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006896> <http://purl.obolibrary.org/obo/FYPO_0003549>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006917> (<http://purl.obolibrary.org/obo/FYPO_0006917>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006917> <http://purl.obolibrary.org/obo/FYPO_0001928>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006936> (<http://purl.obolibrary.org/obo/FYPO_0006936>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006936> <http://purl.obolibrary.org/obo/FYPO_0005544>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006945> (<http://purl.obolibrary.org/obo/FYPO_0006945>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006945> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#has_output> <http://purl.obolibrary.org/obo/FYPO_0002552>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006946> (<http://purl.obolibrary.org/obo/FYPO_0006946>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006946> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006974> (<http://purl.obolibrary.org/obo/FYPO_0006974>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006974> <http://purl.obolibrary.org/obo/FYPO_0005585>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006987> (<http://purl.obolibrary.org/obo/FYPO_0006987>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006987> <http://purl.obolibrary.org/obo/FYPO_0007373>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006997> (<http://purl.obolibrary.org/obo/FYPO_0006997>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006997> <http://purl.obolibrary.org/obo/FYPO_0000443>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006997> <http://purl.obolibrary.org/obo/FYPO_0001352>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006997> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0006998> (<http://purl.obolibrary.org/obo/FYPO_0006998>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006998> <http://purl.obolibrary.org/obo/FYPO_0000443>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006998> <http://purl.obolibrary.org/obo/FYPO_0001352>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0006998> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007004> (<http://purl.obolibrary.org/obo/FYPO_0007004>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007004> <http://purl.obolibrary.org/obo/FYPO_0000443>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007004> <http://purl.obolibrary.org/obo/FYPO_0001352>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007004> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007008> (<http://purl.obolibrary.org/obo/FYPO_0007008>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007008> <http://purl.obolibrary.org/obo/FYPO_0001347>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007009> (<http://purl.obolibrary.org/obo/FYPO_0007009>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007009> <http://purl.obolibrary.org/obo/FYPO_0006356>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007011> (<http://purl.obolibrary.org/obo/FYPO_0007011>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007011> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007027> (<http://purl.obolibrary.org/obo/FYPO_0007027>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007027> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007031> (<http://purl.obolibrary.org/obo/FYPO_0007031>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007031> <http://purl.obolibrary.org/obo/FYPO_0006502>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007052> (<http://purl.obolibrary.org/obo/FYPO_0007052>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007052> <http://purl.obolibrary.org/obo/FYPO_0007051>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007070> (<http://purl.obolibrary.org/obo/FYPO_0007070>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007070> <http://purl.obolibrary.org/obo/FYPO_0001092>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007082> (<http://purl.obolibrary.org/obo/FYPO_0007082>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007082> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007086> (<http://purl.obolibrary.org/obo/FYPO_0007086>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007086> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001122>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007086> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007094> (<http://purl.obolibrary.org/obo/FYPO_0007094>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007094> <http://purl.obolibrary.org/obo/FYPO_0001351>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007095> (<http://purl.obolibrary.org/obo/FYPO_0007095>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007095> <http://purl.obolibrary.org/obo/FYPO_0004802>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007096> (<http://purl.obolibrary.org/obo/FYPO_0007096>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007096> <http://purl.obolibrary.org/obo/FYPO_0004802>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007099> (<http://purl.obolibrary.org/obo/FYPO_0007099>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007099> <http://purl.obolibrary.org/obo/FYPO_0002739>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007101> (<http://purl.obolibrary.org/obo/FYPO_0007101>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007101> <http://purl.obolibrary.org/obo/FYPO_0003607>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007115> (<http://purl.obolibrary.org/obo/FYPO_0007115>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007115> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000783>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007131> (<http://purl.obolibrary.org/obo/FYPO_0007131>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007131> <http://purl.obolibrary.org/obo/FYPO_0000932>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007133> (<http://purl.obolibrary.org/obo/FYPO_0007133>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007133> <http://purl.obolibrary.org/obo/FYPO_0002999>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007136> (<http://purl.obolibrary.org/obo/FYPO_0007136>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007136> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000060>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007136> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007137> (<http://purl.obolibrary.org/obo/FYPO_0007137>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007137> <http://purl.obolibrary.org/obo/FYPO_0000002>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000061>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007137> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007138> (<http://purl.obolibrary.org/obo/FYPO_0007138>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007138> <http://purl.obolibrary.org/obo/FYPO_0002452>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000118>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000645>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007138> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001489>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007140> (<http://purl.obolibrary.org/obo/FYPO_0007140>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007140> <http://purl.obolibrary.org/obo/FYPO_0002415>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007146> (<http://purl.obolibrary.org/obo/FYPO_0007146>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007146> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0004842>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007165> (<http://purl.obolibrary.org/obo/FYPO_0007165>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007165> <http://purl.obolibrary.org/obo/FYPO_0000930>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007169> (<http://purl.obolibrary.org/obo/FYPO_0007169>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007169> <http://purl.obolibrary.org/obo/FYPO_0000297>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007173> (<http://purl.obolibrary.org/obo/FYPO_0007173>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007173> <http://purl.obolibrary.org/obo/FYPO_0001645>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007175> (<http://purl.obolibrary.org/obo/FYPO_0007175>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007175> <http://purl.obolibrary.org/obo/FYPO_0006936>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007176> (<http://purl.obolibrary.org/obo/FYPO_0007176>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007176> <http://purl.obolibrary.org/obo/FYPO_0006936>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007181> (<http://purl.obolibrary.org/obo/FYPO_0007181>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007181> <http://purl.obolibrary.org/obo/FYPO_0002442>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007186> (<http://purl.obolibrary.org/obo/FYPO_0007186>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007186> <http://purl.obolibrary.org/obo/FYPO_0003004>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007193> (<http://purl.obolibrary.org/obo/FYPO_0007193>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007193> <http://purl.obolibrary.org/obo/FYPO_0000359>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007195> (<http://purl.obolibrary.org/obo/FYPO_0007195>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007195> <http://purl.obolibrary.org/obo/FYPO_0000359>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007205> (<http://purl.obolibrary.org/obo/FYPO_0007205>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007205> <http://purl.obolibrary.org/obo/FYPO_0001334>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007205> <http://purl.obolibrary.org/obo/FYPO_0001346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007213> (<http://purl.obolibrary.org/obo/FYPO_0007213>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007213> <http://purl.obolibrary.org/obo/FYPO_0000876>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007218> (<http://purl.obolibrary.org/obo/FYPO_0007218>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007218> <http://purl.obolibrary.org/obo/FYPO_0002362>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007222> (<http://purl.obolibrary.org/obo/FYPO_0007222>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007222> <http://purl.obolibrary.org/obo/FYPO_0001458>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007230> (<http://purl.obolibrary.org/obo/FYPO_0007230>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007230> <http://purl.obolibrary.org/obo/FYPO_0002196>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007231> (<http://purl.obolibrary.org/obo/FYPO_0007231>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007231> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0007230>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007233> (<http://purl.obolibrary.org/obo/FYPO_0007233>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007233> <http://purl.obolibrary.org/obo/FYPO_0006031>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/fypo#output_of> <http://purl.obolibrary.org/obo/FYPO_0007232>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007254> (<http://purl.obolibrary.org/obo/FYPO_0007254>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007254> <http://purl.obolibrary.org/obo/FYPO_0001346>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007257> (<http://purl.obolibrary.org/obo/FYPO_0007257>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007257> <http://purl.obolibrary.org/obo/FYPO_0002772>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007258> (<http://purl.obolibrary.org/obo/FYPO_0007258>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007258> <http://purl.obolibrary.org/obo/FYPO_0007260>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007265> (<http://purl.obolibrary.org/obo/FYPO_0007265>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007265> <http://purl.obolibrary.org/obo/FYPO_0007262>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007272> (<http://purl.obolibrary.org/obo/FYPO_0007272>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007272> <http://purl.obolibrary.org/obo/FYPO_0002540>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007274> (<http://purl.obolibrary.org/obo/FYPO_0007274>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007274> <http://purl.obolibrary.org/obo/FYPO_0000138>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007276> (<http://purl.obolibrary.org/obo/FYPO_0007276>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007276> <http://purl.obolibrary.org/obo/FYPO_0000138>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007282> (<http://purl.obolibrary.org/obo/FYPO_0007282>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000015>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000646>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007282> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0001491>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007290> (<http://purl.obolibrary.org/obo/FYPO_0007290>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007290> <http://purl.obolibrary.org/obo/FYPO_0007289>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007293> (<http://purl.obolibrary.org/obo/FYPO_0007293>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000129>))
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007293> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/FYPO_0000647>))
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007301> (<http://purl.obolibrary.org/obo/FYPO_0007301>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007301> <http://purl.obolibrary.org/obo/FYPO_0001319>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007307> (<http://purl.obolibrary.org/obo/FYPO_0007307>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007307> <http://purl.obolibrary.org/obo/FYPO_0000893>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007307> <http://purl.obolibrary.org/obo/FYPO_0005310>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007309> (<http://purl.obolibrary.org/obo/FYPO_0007309>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007309> <http://purl.obolibrary.org/obo/FYPO_0005308>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007312> (<http://purl.obolibrary.org/obo/FYPO_0007312>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007312> <http://purl.obolibrary.org/obo/FYPO_0005309>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007313> (<http://purl.obolibrary.org/obo/FYPO_0007313>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007313> <http://purl.obolibrary.org/obo/FYPO_0005308>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007315> (<http://purl.obolibrary.org/obo/FYPO_0007315>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007315> <http://purl.obolibrary.org/obo/FYPO_0005308>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007322> (<http://purl.obolibrary.org/obo/FYPO_0007322>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007322> <http://purl.obolibrary.org/obo/FYPO_0007321>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007337> (<http://purl.obolibrary.org/obo/FYPO_0007337>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007337> <http://purl.obolibrary.org/obo/FYPO_0000869>)
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007337> <http://purl.obolibrary.org/obo/FYPO_0007374>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007342> (<http://purl.obolibrary.org/obo/FYPO_0007342>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007342> <http://purl.obolibrary.org/obo/FYPO_0004639>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007343> (<http://purl.obolibrary.org/obo/FYPO_0007343>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007343> <http://purl.obolibrary.org/obo/FYPO_0000335>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007344> (<http://purl.obolibrary.org/obo/FYPO_0007344>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007344> <http://purl.obolibrary.org/obo/FYPO_0003011>)
+
+# Class: <http://purl.obolibrary.org/obo/FYPO_0007357> (<http://purl.obolibrary.org/obo/FYPO_0007357>)
+
 SubClassOf(<http://purl.obolibrary.org/obo/FYPO_0007357> <http://purl.obolibrary.org/obo/FYPO_0007316>)
+
+
 )

--- a/src/ontology/fypo.Makefile
+++ b/src/ontology/fypo.Makefile
@@ -79,3 +79,10 @@ fypotest: tmp/fypo-merge-test.owl tmp/fypotest_report.txt
 
 fix_quality_issue:
 	sed -i 's;ObjectIntersectionOf(<http://purl.obolibrary.org/obo/BFO_0000019>;ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001>;g' $(SRC)
+
+tmp/obsolete-terms.txt: $(SRC)
+	$(ROBOT) query -f csv -i $< --query ../sparql/obsolete-terms.sparql $@
+
+clear_obsoletes: tmp/obsolete-terms.txt
+	$(ROBOT) remove --input components/lost-inferred-subsumptions-pre-odk.owl -T $< -o tmp/$@.ofn && mv tmp/$@.ofn components/lost-inferred-subsumptions-pre-odk.owl
+	

--- a/src/sparql/obsolete-terms.sparql
+++ b/src/sparql/obsolete-terms.sparql
@@ -1,0 +1,11 @@
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX replaced_by: <http://purl.obolibrary.org/obo/IAO_0100001>
+PREFIX consider: <http://www.geneontology.org/formats/oboInOwl#consider>
+
+SELECT DISTINCT ?cls WHERE {
+       ?cls a owl:Class  ;
+	    owl:deprecated "true"^^xsd:boolean .
+}


### PR DESCRIPTION
fixes #3934

The problem is this:
During the migration, we did not want to lose old inferences, so we created a separate component (lost-inferred-subsumptions-pre-odk.owl) which contains them, and are merged in during release. Now we never clear this files of obsoleted classes, and they don't show up in protege (because this file is not an import). 

I have implemented a method for you which you can add to your release SOP:

```
sh run.sh make clear_obsoletes -B
```

Which will remove any axioms related to obsolete classes from that above file. I would basically run this command just before you make a release.

Let me know if something does not make sense! :)